### PR TITLE
Redesign the blog around an editorial travel-magazine style system

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -118,6 +118,7 @@ module.exports = eleventyConfig => {
     eleventyConfig.addFilter('exclude', require('./src/_config/filters/exclude'));
     eleventyConfig.addFilter('withoutTags', require('./src/_config/filters/withoutTags'));
     eleventyConfig.addFilter('escapeHtml', require('./src/_config/filters/escapehtml'));
+    eleventyConfig.addFilter('localeFallback', require('./src/_config/filters/localefallback'));
 
 
     // Passthrough -------------------------------------

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -115,6 +115,9 @@ module.exports = eleventyConfig => {
     eleventyConfig.addFilter('sort', require('./src/_config/filters/sort'));
     eleventyConfig.addFilter('base64', require('./src/_config/filters/base64'));
     eleventyConfig.addFilter('readingTime', require('./src/_config/filters/readingtime'));
+    eleventyConfig.addFilter('exclude', require('./src/_config/filters/exclude'));
+    eleventyConfig.addFilter('withoutTags', require('./src/_config/filters/withoutTags'));
+    eleventyConfig.addFilter('escapeHtml', require('./src/_config/filters/escapehtml'));
 
 
     // Passthrough -------------------------------------

--- a/README.md
+++ b/README.md
@@ -16,6 +16,42 @@ The project is organized as follows:
   - `_includes/`: Contains components.
   - `_layouts/`: Contains layouts of the pages.
 
+## Design system
+
+The blog runs on a token-driven CSS design system — no framework, no utility
+classes. Everything visual resolves back to a custom property, so dark mode and
+future tweaks stay cheap.
+
+- `src/assets/css/variables.css` — design tokens: brand palette, semantic
+  colours, type scale, spacing, radii, shadows, motion. **Add new values here
+  rather than hard-coding them in a component.**
+- `src/assets/css/reset.css` — modern reset.
+- `src/assets/css/styles.css` — element defaults, layout shells (`.shell`,
+  `.section`, `.grid`) and shared utilities.
+- `src/assets/css/components/*.css` — one file per component (buttons, cards,
+  hero, navigation, prose, footer, …).
+- `src/assets/css/bundle.njk` — concatenates the above into
+  `/assets/css/bundle.css`. New component files must be added here.
+
+### Style guide
+
+A living style guide is published at **[`/styleguide/`](https://daniela-and-will-travel.github.io/styleguide/)**
+(`src/styleguide.njk`). Every example on that page is rendered with the real
+stylesheet and shown next to the markup that produced it, so it never drifts
+from the site.
+
+Check it before building a new page, and add a story to it when you add a
+component. Stories are written as:
+
+```njk
+{% set myMarkup %}
+<a class="button" href="#">Browse destinations</a>
+{% endset %}
+{{ story('Label', myMarkup, 'optional note') }}
+```
+
+The same string is rendered live and printed as escaped source.
+
 ## Getting Started
 
 To get started with this project, follow these steps:
@@ -68,6 +104,9 @@ tags:
  - itinerary
  - planning
 draft: false
+byline: How to visit Japan on a bougie backpacker budget!
+heroImage: /assets/img/posts/asia/IMG_0495.jpg
+heroImageAlt: A street scene in Japan
 eleventyExcludeFromCollections: false
 seo:
   title: One Week Japan Itinerary
@@ -75,6 +114,12 @@ seo:
   changeFrequency: monthly
 ---
 ```
+
+`byline`, `heroImage` and `heroImageAlt` are what make a post look right in the
+card grids on the home page, the countries page and the related-posts strip —
+don't ship a post without them. See the
+[style guide](https://daniela-and-will-travel.github.io/styleguide/#frontmatter)
+for the full list of keys and where each one appears.
 
 ### Deployment
 

--- a/src/404.md
+++ b/src/404.md
@@ -9,8 +9,14 @@ seo:
   description: Sorry, the page you were looking for could not be found.
 ---
 
-# Page Not Found
-
-Sorry, the page you were looking for could not be found. It may have moved, or the link may be out of date.
-
-[Head back to the homepage](/) or check out our latest travel guides from there.
+<div class="page-hero">
+  <div class="page-hero__inner">
+    <p class="eyebrow">Error 404</p>
+    <h1 class="page-hero__title">This one's off the map</h1>
+    <p class="page-hero__lede">Sorry, the page you were looking for could not be found. It may have moved, or the link may be out of date.</p>
+    <div class="hero__actions">
+      <a class="button" href="/">Back to the homepage</a>
+      <a class="button button--outline" href="/en/countries/">Browse destinations</a>
+    </div>
+  </div>
+</div>

--- a/src/_config/filters/escapehtml.js
+++ b/src/_config/filters/escapehtml.js
@@ -1,0 +1,15 @@
+// escape a chunk of markup so it can be shown as source in the style guide
+// {{ markup | escapeHtml | safe }}
+const ENTITIES = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+};
+
+module.exports = function (value) {
+    return String(value === undefined || value === null ? '' : value)
+        .replace(/[&<>"']/g, (char) => ENTITIES[char])
+        .trim();
+};

--- a/src/_config/filters/exclude.js
+++ b/src/_config/filters/exclude.js
@@ -1,0 +1,6 @@
+// remove the current page from a collection
+// {% set related = collections.posts | exclude(page.url) %}
+module.exports = function (collection, url) {
+    if (!Array.isArray(collection)) return [];
+    return collection.filter((item) => item.url !== url);
+};

--- a/src/_config/filters/localefallback.js
+++ b/src/_config/filters/localefallback.js
@@ -1,0 +1,26 @@
+// Guarantee a URL carries a language prefix.
+//
+// EleventyI18nPlugin's `locale_url` only rewrites a URL when a version of that
+// page exists in the current language — otherwise it hands the URL straight
+// back. For pages that only exist in one language (the legal pages, for
+// example) that produces an unprefixed, 404-ing link on every other locale.
+//
+// Chaining this filter after `locale_url` keeps the localized URL when there is
+// one and falls back to the default language when there is not:
+//
+//   {{ "/affiliates/" | locale_url | localeFallback }}
+//
+// The day a Spanish version is added, `locale_url` resolves it and this filter
+// leaves the result alone.
+const locales = require('../../_data/locales');
+
+const LANGUAGE_CODES = Object.keys(locales);
+
+module.exports = function (url, fallback = 'en') {
+    if (typeof url !== 'string' || !url.startsWith('/')) return url;
+
+    const [firstSegment] = url.slice(1).split('/');
+    if (LANGUAGE_CODES.includes(firstSegment)) return url;
+
+    return `/${fallback}${url}`;
+};

--- a/src/_config/filters/withoutTags.js
+++ b/src/_config/filters/withoutTags.js
@@ -1,0 +1,10 @@
+// strip the structural tags Eleventy adds so only editorial tags are shown
+// {% set postTags = tags | withoutTags %}
+const STRUCTURAL = ['posts', 'page', 'home', 'all'];
+
+module.exports = function (tags, extra = []) {
+    if (!tags) return [];
+    const list = Array.isArray(tags) ? tags : [tags];
+    const removed = STRUCTURAL.concat(extra);
+    return list.filter((tag) => !removed.includes(tag));
+};

--- a/src/_data/translations.js
+++ b/src/_data/translations.js
@@ -9,7 +9,9 @@ module.exports = {
         },
         header: {
             skipLink: 'Skip to content',
-            home: 'Home'
+            home: 'Home',
+            menu: 'Menu',
+            close: 'Close'
         },
         readingTime: {
             underMinute: 'Less than 1 minute to read',
@@ -19,6 +21,25 @@ module.exports = {
         feeds: {
             info: 'This is an RSS feed. Copy and paste the URL into your feed reader. Visit <a href="https://aboutfeeds.com">About Feeds</a> to learn more about RSS.',
             title: 'Recently Published'
+        },
+        footer: {
+            tagline: "Travel guides, itineraries and honest advice from nine months across Europe and four months through Southeast Asia — so you don't make the same mistakes we did.",
+            explore: 'Explore',
+            smallPrint: 'The Small Print',
+            affiliates: 'Affiliate Disclosure',
+            privacy: 'Privacy Policy',
+            terms: 'Terms of Use',
+            doNotSell: 'Do Not Sell My Info',
+            styleGuide: 'Style Guide',
+            builtWith: 'Built with <a href="https://elva.scott.ee/">Elva</a> on <a href="https://www.11ty.dev/">Eleventy</a>. Icons by <a href="https://fontawesome.com/">Font Awesome</a>.'
+        },
+        post: {
+            by: 'By {{ author }}',
+            affiliateNotice: 'This post may contain affiliate links, which help support us at no cost to you! Learn&nbsp;more',
+            affiliateLink: 'here',
+            relatedEyebrow: 'Keep reading',
+            relatedTitle: 'More travel guides',
+            backToTop: 'Back to top'
         },
         dark: 'Dark',
         light: 'Light'
@@ -33,7 +54,9 @@ module.exports = {
         },
         header: {
             skipLink: 'Saltar al contenido',
-            home: 'Inicio'
+            home: 'Inicio',
+            menu: 'Menú',
+            close: 'Cerrar'
         },
         readingTime: {
             underMinute: 'Menos de 1 minuto para leer',
@@ -43,6 +66,25 @@ module.exports = {
         feeds: {
             info: 'Este es un feed RSS. Copia y pega la URL en tu lector de feeds. Visita <a href="https://aboutfeeds.com">About Feeds</a> para obtener más información sobre RSS.',
             title: 'Publicado Recientemente'
+        },
+        footer: {
+            tagline: 'Guías de viaje, itinerarios y consejos honestos de nueve meses por Europa y cuatro meses por el Sudeste Asiático — para que no cometas los mismos errores que nosotros.',
+            explore: 'Explorar',
+            smallPrint: 'La Letra Pequeña',
+            affiliates: 'Divulgación de Afiliados',
+            privacy: 'Política de Privacidad',
+            terms: 'Términos de Uso',
+            doNotSell: 'No Vendan Mi Información',
+            styleGuide: 'Guía de Estilo',
+            builtWith: 'Hecho con <a href="https://elva.scott.ee/">Elva</a> sobre <a href="https://www.11ty.dev/">Eleventy</a>. Iconos de <a href="https://fontawesome.com/">Font Awesome</a>.'
+        },
+        post: {
+            by: 'Por {{ author }}',
+            affiliateNotice: 'Esta publicación puede contener enlaces de afiliados, que nos ayudan sin ningún costo para ti. Más&nbsp;información',
+            affiliateLink: 'aquí',
+            relatedEyebrow: 'Sigue leyendo',
+            relatedTitle: 'Más guías de viaje',
+            backToTop: 'Volver arriba'
         },
         dark: 'Oscuro',
         light: 'Claro'

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -5,7 +5,7 @@
 
             <div class="footer__brand">
                 <a class="footer__wordmark" href="/">Daniela and Will</a>
-                <p class="footer__tagline">Travel guides, itineraries and honest advice from nine months across Europe and four months through Southeast Asia — so you don't make the same mistakes we did.</p>
+                <p class="footer__tagline">{{ 'footer.tagline' | translate }}</p>
                 <ul class="social-menu">
                     <li><a href="https://www.instagram.com/danielaandwill">Instagram</a></li>
                     <li><a href="https://www.youtube.com/channel/UC5ccB45YDsFrsZ305iKi7HQ">YouTube</a></li>
@@ -14,24 +14,24 @@
             </div>
 
             <div>
-                <h2 class="footer__heading">Explore</h2>
+                <h2 class="footer__heading">{{ 'footer.explore' | translate }}</h2>
                 <ul class="footer__list">
                     {% set footerNavigation = navigation[page.lang] or navigation['en'] %}
                     {% for item in footerNavigation %}
                     <li><a href="{{ item.url | locale_url }}">{{ item.text }}</a></li>
                     {% endfor %}
-                    <li><a href="{{ "/feed/feed.xml" | locale_url }}">RSS Feed</a></li>
+                    <li><a href="{{ "/feed/feed.xml" | locale_url }}">{{ 'meta.rssTitle' | translate }}</a></li>
                 </ul>
             </div>
 
             <div>
-                <h2 class="footer__heading">The Small Print</h2>
+                <h2 class="footer__heading">{{ 'footer.smallPrint' | translate }}</h2>
                 <ul class="footer__list">
-                    <li><a href="{{ "/affiliates/" | locale_url }}">Affiliate Disclosure</a></li>
-                    <li><a href="{{ "/privacy/" | locale_url }}">Privacy Policy</a></li>
-                    <li><a href="{{ "/terms/" | locale_url }}">Terms of Use</a></li>
-                    <li><a href="{{ "/do-not-sell-my-personal-information/" | locale_url }}">Do Not Sell My Info</a></li>
-                    <li><a href="/styleguide/">Style Guide</a></li>
+                    <li><a href="{{ "/affiliates/" | locale_url | localeFallback }}">{{ 'footer.affiliates' | translate }}</a></li>
+                    <li><a href="{{ "/privacy/" | locale_url | localeFallback }}">{{ 'footer.privacy' | translate }}</a></li>
+                    <li><a href="{{ "/terms/" | locale_url | localeFallback }}">{{ 'footer.terms' | translate }}</a></li>
+                    <li><a href="{{ "/do-not-sell-my-personal-information/" | locale_url | localeFallback }}">{{ 'footer.doNotSell' | translate }}</a></li>
+                    <li><a href="/styleguide/">{{ 'footer.styleGuide' | translate }}</a></li>
                 </ul>
             </div>
 
@@ -50,7 +50,7 @@
 
         <div class="footer__bottom">
             <p class="copyright"><span id="current-year">© 2022 - {% year %} Daniela and Will</span></p>
-            <p class="copyright">Built with <a href="https://elva.scott.ee/">Elva</a> on <a href="https://www.11ty.dev/">Eleventy</a>. Icons by <a href="https://fontawesome.com/">Font Awesome</a>.</p>
+            <p class="copyright">{{ 'footer.builtWith' | translate | safe }}</p>
         </div>
 
     </div>

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,22 +1,66 @@
+<footer id="footer" class="footer">
+    <div class="footer__inner">
+
+        <div class="footer__top">
+
+            <div class="footer__brand">
+                <a class="footer__wordmark" href="/">Daniela and Will</a>
+                <p class="footer__tagline">Travel guides, itineraries and honest advice from nine months across Europe and four months through Southeast Asia — so you don't make the same mistakes we did.</p>
+                <ul class="social-menu">
+                    <li><a href="https://www.instagram.com/danielaandwill">Instagram</a></li>
+                    <li><a href="https://www.youtube.com/channel/UC5ccB45YDsFrsZ305iKi7HQ">YouTube</a></li>
+                    <li><a href="https://unsplash.com/@william_vdg">Unsplash</a></li>
+                </ul>
+            </div>
+
+            <div>
+                <h2 class="footer__heading">Explore</h2>
+                <ul class="footer__list">
+                    {% set footerNavigation = navigation[page.lang] or navigation['en'] %}
+                    {% for item in footerNavigation %}
+                    <li><a href="{{ item.url | locale_url }}">{{ item.text }}</a></li>
+                    {% endfor %}
+                    <li><a href="{{ "/feed/feed.xml" | locale_url }}">RSS Feed</a></li>
+                </ul>
+            </div>
+
+            <div>
+                <h2 class="footer__heading">The Small Print</h2>
+                <ul class="footer__list">
+                    <li><a href="{{ "/affiliates/" | locale_url }}">Affiliate Disclosure</a></li>
+                    <li><a href="{{ "/privacy/" | locale_url }}">Privacy Policy</a></li>
+                    <li><a href="{{ "/terms/" | locale_url }}">Terms of Use</a></li>
+                    <li><a href="{{ "/do-not-sell-my-personal-information/" | locale_url }}">Do Not Sell My Info</a></li>
+                    <li><a href="/styleguide/">Style Guide</a></li>
+                </ul>
+            </div>
+
+            <div class="footer__utilities">
+                {% include "switch-darkmode.njk" %}
+
+                <a href="{{ "/feed/feed.xml" | locale_url }}" class="rss-icon" aria-label="{{ 'meta.rssTitle' | translate }}">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-labelledby="icon-rss" role="img" width="24" height="24">
+                        <title id="icon-rss">{{ 'meta.rssTitle' | translate }}</title>
+                        <path d="M6.18,15.64A2.18,2.18 0 0,1 8.36,17.82C8.36,19 7.38,20 6.18,20C5,20 4,19 4,17.82A2.18,2.18 0 0,1 6.18,15.64M4,4.44A15.56,15.56 0 0,1 19.56,20H16.73A12.73,12.73 0 0,0 4,7.27V4.44M4,10.1A9.9,9.9 0 0,1 13.9,20H11.07A7.07,7.07 0 0,0 4,12.93V10.1Z" fill="currentColor" />
+                    </svg>
+                </a>
+            </div>
+
+        </div>
+
+        <div class="footer__bottom">
+            <p class="copyright"><span id="current-year">© 2022 - {% year %} Daniela and Will</span></p>
+            <p class="copyright">Built with <a href="https://elva.scott.ee/">Elva</a> on <a href="https://www.11ty.dev/">Eleventy</a>. Icons by <a href="https://fontawesome.com/">Font Awesome</a>.</p>
+        </div>
+
+    </div>
+</footer>
+
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      document.getElementById('current-year').textContent = "© 2022 - " + new Date().getFullYear() + " Daniela and Will";
+    document.addEventListener('DOMContentLoaded', function () {
+        var el = document.getElementById('current-year');
+        if (el) {
+            el.textContent = '© 2022 - ' + new Date().getFullYear() + ' Daniela and Will';
+        }
     });
 </script>
-
-<!--<span style="text-align: center; padding: 6px;">We are trying out a new blog platform + design! If you have any feedback please leave it <a href="https://docs.google.com/forms/d/e/1FAIpQLSfsbQQcA882d2Vlz6SvQcrQesoPQGmhR3KufmHv7Nazd4rUZQ/viewform?usp=header">here</a>!</span>-->
-
-<footer id="footer" class="footer">
-
-    {% include "switch-darkmode.njk" %}
-
-    <p class="copyright" ><span id="current-year"></span> - built with <a href="https://elva.scott.ee/">Elva</a> + <a href="https://fontawesome.com/">Font Awesome</a> on <a href="https://www.11ty.dev/">Eleventy</a></p>
-    
-    <a href="{{ "/feed/feed.xml" | locale_url }}" class="rss-icon" aria-label="{{ 'meta.rssTitle' | translate }}" >
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-labelledby="icon-rss" role="img" width="24" height="24">
-            <title id="icon-rss">{{ 'meta.rssTitle' | translate }}</title>
-            <path d="M6.18,15.64A2.18,2.18 0 0,1 8.36,17.82C8.36,19 7.38,20 6.18,20C5,20 4,19 4,17.82A2.18,2.18 0 0,1 6.18,15.64M4,4.44A15.56,15.56 0 0,1 19.56,20H16.73A12.73,12.73 0 0,0 4,7.27V4.44M4,10.1A9.9,9.9 0 0,1 13.9,20H11.07A7.07,7.07 0 0,0 4,12.93V10.1Z" fill="currentColor" />
-        </svg>
-    </a>
-
-</footer>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,6 +1,6 @@
-<header id="header" role="banner" class="header">
+<a href="#content" class="skip-link">{{ 'header.skipLink' | translate }}</a>
 
-    <a href="#content" class="skip-link screen-reader-text">{{ 'header.skipLink' | translate }}</a>
+<header id="header" role="banner" class="site-header">
 
     {% include "navigation.njk" %}
 

--- a/src/_includes/navigation.njk
+++ b/src/_includes/navigation.njk
@@ -73,7 +73,7 @@
         @click="open = !open"
     >
         <span class="navigation-toggle__bars" aria-hidden="true"><span></span><span></span><span></span></span>
-        <span x-text="open ? 'Close' : 'Menu'">Menu</span>
+        <span x-text="open ? '{{ 'header.close' | translate }}' : '{{ 'header.menu' | translate }}'">{{ 'header.menu' | translate }}</span>
     </button>
 
     <div class="navigation-panel" id="site-menu" data-open="false" :data-open="open ? 'true' : 'false'">

--- a/src/_includes/navigation.njk
+++ b/src/_includes/navigation.njk
@@ -1,6 +1,5 @@
-<nav class="navigation">
+<nav class="navigation" x-data="{ open: false }" @keydown.escape.window="open = false">
     <a class="site-logo" href="/" {% if page.url === '/' %}aria-current="page"{% endif %} aria-label="{{ 'header.home' | translate }}">
-        <?xml version="1.0" encoding="UTF-8"?>
         <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54.35 58.63">
             <g>
                 <path class="cls-2" d="m34.24,17.2c-.75,1.28.57,3.13.76,2.27.09-.38.38-.21.5-.58.1-.3-.03-1.43.34-1.43.25,0,.25-.34.39-.54.26-.37.81.73,1.07.37.06-.08.13-.16.2-.23.13-.15.31-.26.5-.19.2.08-.3-1.24-.28-1,.03.36-.02.7-.14,1.03-.1.27-.27.48-.53.6-.41.19-.23.97-.34,1.44-.01.06,1.17-.84,1.18-.8.14.39.46.54.64.92"/>
@@ -64,22 +63,39 @@
             </g>
         </svg>
     </a>
-    
-    <ul class="navigation-menu">
-        {% for item in navigation[page.lang] %}
-        {%- set url = item.url | locale_url %}
-        <li>
-            <a 
-                href="{{ url }}"
-                {% if page.url === url %}aria-current="page"{% endif %}
-            >
-                {{ item.text }}
-            </a>
-        </li>
-        {%- endfor %}
-    </ul>
-    
-    {% include "social-icons.njk" %}
 
-    {# {% include "switch-il8n.njk" %} #}
+    <button
+        type="button"
+        class="navigation-toggle"
+        aria-controls="site-menu"
+        aria-expanded="false"
+        :aria-expanded="open ? 'true' : 'false'"
+        @click="open = !open"
+    >
+        <span class="navigation-toggle__bars" aria-hidden="true"><span></span><span></span><span></span></span>
+        <span x-text="open ? 'Close' : 'Menu'">Menu</span>
+    </button>
+
+    <div class="navigation-panel" id="site-menu" data-open="false" :data-open="open ? 'true' : 'false'">
+        <ul class="navigation-menu">
+            {% set navigationItems = navigation[page.lang] or navigation['en'] %}
+            {% for item in navigationItems %}
+            {%- set url = item.url | locale_url %}
+            <li>
+                <a
+                    href="{{ url }}"
+                    {% if page.url === url %}aria-current="page"{% endif %}
+                    @click="open = false"
+                >
+                    {{ item.text }}
+                </a>
+            </li>
+            {%- endfor %}
+        </ul>
+
+        <div class="navigation-utilities">
+            {% include "social-icons.njk" %}
+            {# {% include "switch-il8n.njk" %} #}
+        </div>
+    </div>
 </nav>

--- a/src/_includes/posts.njk
+++ b/src/_includes/posts.njk
@@ -1,7 +1,7 @@
 {% set postslist = collections.posts | languageFilter | reverse %}
 <div class="grid">
 {% for post in postslist %}
-	<article class="card{% if post.url === page.url %} postlist-item-active{% endif %}">
+	<article class="card{% if not post.data.heroImage %} card--minimal{% endif %}{% if post.url === page.url %} postlist-item-active{% endif %}">
 		{% if post.data.heroImage %}
 		<div class="card__media">
 			{% image post.data.heroImage, post.data.heroImageAlt, "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}

--- a/src/_includes/posts.njk
+++ b/src/_includes/posts.njk
@@ -1,9 +1,17 @@
 {% set postslist = collections.posts | languageFilter | reverse %}
-<ol reversed class="postlist" style="counter-reset: start-from {{ postslist.length + 1 }}">
+<div class="grid">
 {% for post in postslist %}
-	<li class="postlist-item{% if post.url === url %} postlist-item-active{% endif %}">
-		<a href="{{ post.url }}" class="postlist-link">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
-		<time class="postlist-date" datetime="{{ post.date | dateToRfc3339 }}">{{ post.date | formatDate }}</time>
-	</li>
+	<article class="card{% if post.url === page.url %} postlist-item-active{% endif %}">
+		{% if post.data.heroImage %}
+		<div class="card__media">
+			{% image post.data.heroImage, post.data.heroImageAlt, "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}
+		</div>
+		{% endif %}
+		<div class="card__body">
+			<h2 class="card__title"><a href="{{ post.url }}">{% if post.data.title %}{{ post.data.title }}{% else %}{{ post.url }}{% endif %}</a></h2>
+			{% if post.data.byline %}<p class="card__excerpt">{{ post.data.byline }}</p>{% endif %}
+			<p class="card__meta"><time datetime="{{ post.date | dateToRfc3339 }}">{{ post.date | formatDate }}</time></p>
+		</div>
+	</article>
 {% endfor %}
-</ol>
+</div>

--- a/src/_includes/social-icons.njk
+++ b/src/_includes/social-icons.njk
@@ -7,8 +7,8 @@
 	</span>
 </div> #}
 
-<ul class="social-menu" style="text-align: right;">
-	<li><p><a href="https://www.instagram.com/danielaandwill">Instagram</a></p></li>
-	<li><p><a href="https://unsplash.com/@william_vdg" title="Follow William on Unsplash →">Unsp</a><a href="https://unsplash.com/@danielaasada" title="← Follow Daniela on Unsplash">lash</a></p></li>
-	<li><p><a href="https://www.youtube.com/channel/UC5ccB45YDsFrsZ305iKi7HQ">YouTube</a></p></li>
+<ul class="social-menu">
+	<li><a href="https://www.instagram.com/danielaandwill">Instagram</a></li>
+	<li><a href="https://unsplash.com/@william_vdg" title="Follow William on Unsplash →">Unsp</a><a href="https://unsplash.com/@danielaasada" title="← Follow Daniela on Unsplash">lash</a></li>
+	<li><a href="https://www.youtube.com/channel/UC5ccB45YDsFrsZ305iKi7HQ">YouTube</a></li>
 </ul>

--- a/src/_layouts/home.njk
+++ b/src/_layouts/home.njk
@@ -1,7 +1,17 @@
 ---
 layout: base
 ---
-<div class="posts-list">
-    {% include "posts.njk" %}
-    {{ content | safe }}
-</div>
+<header class="page-hero">
+    <div class="page-hero__inner">
+        <p class="eyebrow">The archive</p>
+        <h1 class="page-hero__title">{{ title or 'Every travel guide' }}</h1>
+        {% if byline %}<p class="page-hero__lede">{{ byline }}</p>{% endif %}
+    </div>
+</header>
+
+<section class="section section--tight">
+    <div class="shell">
+        {% include "posts.njk" %}
+        {{ content | safe }}
+    </div>
+</section>

--- a/src/_layouts/page.njk
+++ b/src/_layouts/page.njk
@@ -2,10 +2,19 @@
 layout: base
 ---
 <article class="hentry">
-    <header class="entry-header">
-        <h1 class="entry-title">{{title}}</h1>
+
+    <header class="page-hero">
+        <div class="page-hero__inner">
+            {% if eyebrow %}<p class="eyebrow">{{ eyebrow }}</p>{% endif %}
+            <h1 class="page-hero__title entry-title">{{ title }}</h1>
+            {% if byline or seo.description %}
+            <p class="page-hero__lede">{{ byline or seo.description }}</p>
+            {% endif %}
+        </div>
     </header>
-    <div class="entry-content">
+
+    <div class="entry-content prose">
         {{ content | safe }}
     </div>
+
 </article>

--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -10,7 +10,7 @@ layout: base
         <div class="post-hero__inner">
 
             <ol class="breadcrumb">
-                <li><a href="/">Home</a></li>
+                <li><a href="/">{{ 'header.home' | translate }}</a></li>
                 {%- if postTags.length %}<li>{{ postTags[0] | replace("-", " ") }}</li>{% endif %}
             </ol>
 
@@ -21,7 +21,7 @@ layout: base
             {% endif %}
 
             <ul class="meta-line post-hero__meta">
-                <li class="meta-author">By {{ author or settings.author.name }}</li>
+                <li class="meta-author">{{ 'post.by' | translate(page.lang, { author: author or settings.author.name }) }}</li>
                 <li class="meta-date">
                     <time class="entry-date published" datetime="{{ date | dateToRfc3339 }}">{{ date | formatDate }}</time>
                 </li>
@@ -34,7 +34,7 @@ layout: base
     <div class="entry-content prose">
 
         <div class="affiliate">
-            This post may contain affiliate links, which help support us at no cost to you! Learn&nbsp;more&nbsp;<a href="{{ "/affiliates/" | locale_url }}">here</a>.
+            {{ 'post.affiliateNotice' | translate | safe }}&nbsp;<a href="{{ "/affiliates/" | locale_url | localeFallback }}">{{ 'post.affiliateLink' | translate }}</a>.
         </div>
 
         {{ content | safe }}
@@ -56,12 +56,12 @@ layout: base
     <section class="section section--tinted">
         <div class="shell">
             <div class="section-header section-header--center">
-                <p class="eyebrow">Keep reading</p>
-                <h2 class="section-header__title">More travel guides</h2>
+                <p class="eyebrow">{{ 'post.relatedEyebrow' | translate }}</p>
+                <h2 class="section-header__title">{{ 'post.relatedTitle' | translate }}</h2>
             </div>
             <div class="grid">
                 {% for post in relatedPosts %}
-                <article class="card">
+                <article class="card{% if not post.data.heroImage %} card--minimal{% endif %}">
                     {% if post.data.heroImage %}
                     <div class="card__media">
                         {% image post.data.heroImage, post.data.heroImageAlt, "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}
@@ -78,7 +78,7 @@ layout: base
     </section>
     {% endif %}
 
-    <button id="return-to-top" class="return-to-top" aria-label="Back to top" onclick="scrollToTop()">↑</button>
+    <button id="return-to-top" class="return-to-top" aria-label="{{ 'post.backToTop' | translate }}" onclick="scrollToTop()">↑</button>
 
 </article>
 

--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -1,45 +1,94 @@
 ---
 layout: base
 ---
-<article class="hentry">
-    <header class="entry-header">
-        <h1 class="entry-title">{{title}}</h1>
-        <ul class="meta">
-            <li class="meta-date">
-                <time class="entry-date published" datatime="{{ date | dateToRfc3339 }}">{{ date | formatDate }}</time>
-            </li>
-            <li class="meta-author">by {{ author }}</li>
-            <li class="meta-reading-time">{{ content | readingTime }}</li>
-        </ul>
-    </header>
-    
-    <div class="affiliate">
-        This post may contain affiliate links, which help support us at no cost to you! Learn&nbsp;more&nbsp;<a href="/en/affiliates">here</a>.
-    </div>
+{%- set postTags = tags | withoutTags -%}
+{%- set relatedPosts = collections.posts | languageFilter(page.lang) | exclude(page.url) | reverse | batch(3) | first -%}
 
-    <div class="entry-content">
+<article class="hentry post">
+
+    <header class="post-hero">
+        <div class="post-hero__inner">
+
+            <ol class="breadcrumb">
+                <li><a href="/">Home</a></li>
+                {%- if postTags.length %}<li>{{ postTags[0] | replace("-", " ") }}</li>{% endif %}
+            </ol>
+
+            <h1 class="post-hero__title entry-title">{{ title }}</h1>
+
+            {% if byline %}
+            <p class="post-hero__byline">{{ byline }}</p>
+            {% endif %}
+
+            <ul class="meta-line post-hero__meta">
+                <li class="meta-author">By {{ author or settings.author.name }}</li>
+                <li class="meta-date">
+                    <time class="entry-date published" datetime="{{ date | dateToRfc3339 }}">{{ date | formatDate }}</time>
+                </li>
+                <li class="meta-reading-time">{{ content | readingTime }}</li>
+            </ul>
+
+        </div>
+    </header>
+
+    <div class="entry-content prose">
+
+        <div class="affiliate">
+            This post may contain affiliate links, which help support us at no cost to you! Learn&nbsp;more&nbsp;<a href="{{ "/affiliates/" | locale_url }}">here</a>.
+        </div>
+
         {{ content | safe }}
     </div>
-    <br>
 
-    {% include "affiliates.njk" %}
-    
-    <button id="return-to-top" class="return-to-top" onclick="scrollToTop()">↑ Top</button>
+    <footer class="post-footer">
+
+        {% if postTags.length %}
+        <ul class="post-tags">
+            {%- for tag in postTags %}<li><span class="tag">{{ tag | replace("-", " ") }}</span></li>{% endfor %}
+        </ul>
+        {% endif %}
+
+        {% include "affiliates.njk" %}
+
+    </footer>
+
+    {% if relatedPosts.length %}
+    <section class="section section--tinted">
+        <div class="shell">
+            <div class="section-header section-header--center">
+                <p class="eyebrow">Keep reading</p>
+                <h2 class="section-header__title">More travel guides</h2>
+            </div>
+            <div class="grid">
+                {% for post in relatedPosts %}
+                <article class="card">
+                    {% if post.data.heroImage %}
+                    <div class="card__media">
+                        {% image post.data.heroImage, post.data.heroImageAlt, "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}
+                    </div>
+                    {% endif %}
+                    <div class="card__body">
+                        <h3 class="card__title"><a href="{{ post.url }}">{{ post.data.title }}</a></h3>
+                        {% if post.data.byline %}<p class="card__excerpt">{{ post.data.byline }}</p>{% endif %}
+                    </div>
+                </article>
+                {% endfor %}
+            </div>
+        </div>
+    </section>
+    {% endif %}
+
+    <button id="return-to-top" class="return-to-top" aria-label="Back to top" onclick="scrollToTop()">↑</button>
 
 </article>
 
 <script>
-    // Show the button when scrolling down
     window.addEventListener('scroll', function () {
         const button = document.getElementById('return-to-top');
-        if (window.scrollY > 300) {
-            button.style.display = 'block';
-        } else {
-            button.style.display = 'none';
-        }
+        if (!button) return;
+        button.style.display = window.scrollY > 400 ? 'flex' : 'none';
     });
 
-    // Scroll to the top of the page
     function scrollToTop() {
         window.scrollTo({ top: 0, behavior: 'smooth' });
     }

--- a/src/assets/css/bundle.njk
+++ b/src/assets/css/bundle.njk
@@ -4,11 +4,19 @@ eleventyExcludeFromCollections: true
 seo:
   excludeFromSitemap: true
 ---
-{% include "./reset.css" %}
 {% include "./variables.css" %}
+{% include "./reset.css" %}
 {% include "./styles.css" %}
+{% include "./components/button.css" %}
+{% include "./components/navigation.css" %}
+{% include "./components/hero.css" %}
+{% include "./components/card.css" %}
+{% include "./components/prose.css" %}
+{% include "./components/newsletter.css" %}
+{% include "./components/footer.css" %}
 {% include "./components/syntax.css" %}
 {% include "./components/affiliates.css" %}
 {% include "./components/switch-il8n.css" %}
 {% include "./components/social-icons.css" %}
 {% include "./components/switch-darkmode.css" %}
+{% include "./components/styleguide.css" %}

--- a/src/assets/css/components/affiliates.css
+++ b/src/assets/css/components/affiliates.css
@@ -1,83 +1,88 @@
-/* for desktop */
-.affiliate-desktop {
-    border: 1px solid var(--background);
-    border-radius: var(--border-radius);
-    padding: 10px;
-    margin-bottom: 20px;
-    max-width: 65ch;
-    text-align: center;
-    background-color: var(--foreground);
-    font-size: var(--step-0);
-    color: var(--background);
-}
+/* =========================================================================
+   Affiliate partner grid shown at the foot of every post
+   ========================================================================= */
 
-/* for mobile */
+.affiliate-desktop,
 .affiliate-mobile {
-    border: 1px solid var(--background);
-    border-radius: var(--border-radius);
-    padding: 10px;
-    margin-bottom: 20px;
-    max-width: 65ch;
-    text-align: center;
-    background-color: var(--foreground);
-    font-size: var(--step-0);
-    color: var(--background);
+    background-color: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-l);
+    padding: var(--space-m);
+    max-width: none;
 }
 
-/* for desktop */
-.affiliate-box-desktop{
-    -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
-    -moz-box-sizing: border-box;    /* Firefox, other Gecko */
-    box-sizing: border-box;         /* Opera/IE 8+ */
-    border: 1px solid var(--background);
-    border-radius: var(--border-radius); 
-    width: 50%;
-    margin: var(--space-3xs);
-    padding: var(--space-3xs);
+.affiliate-desktop > div,
+.affiliate-mobile > div {
+    display: grid !important;
+    gap: var(--space-2xs);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
 }
 
-/* for mobile */
-.affiliate-box-mobile{
-    -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
-    -moz-box-sizing: border-box;    /* Firefox, other Gecko */
-    box-sizing: border-box;         /* Opera/IE 8+ */
-    border: 1px solid var(--background);
-    border-radius: var(--border-radius); 
-    width: 100%;
-    margin: var(--space-3xs);
-    padding: var(--space-3xs);
+.affiliate-box-desktop,
+.affiliate-box-mobile {
+    box-sizing: border-box;
+    width: 100% !important;
+    margin: 0;
+    padding: var(--space-s);
+    background-color: var(--surface-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-m);
+    transition: border-color var(--transition-base), box-shadow var(--transition-base),
+        transform var(--transition-base);
 }
 
-.affiliate-link{
-    display: flex; 
-    align-items: center; 
-    text-decoration: none; 
-    color: inherit;
+.affiliate-box-desktop:hover,
+.affiliate-box-mobile:hover {
+    border-color: var(--accent-soft);
+    box-shadow: var(--shadow-s);
+    transform: translateY(-2px);
 }
 
-.affiliate-link:hover{
-    color: var(--link);
+.affiliate-link {
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
+    gap: var(--space-s);
+    text-decoration: none;
+    color: var(--ink);
 }
 
-.affiliate-inner-box{
+.affiliate-link:hover {
+    color: var(--accent-deep);
+}
+
+.affiliate-link strong {
+    font-family: var(--font-display);
+    font-size: var(--step--1);
+    letter-spacing: var(--tracking-tight);
+    color: var(--ink-strong);
+}
+
+.affiliate-link span {
+    font-size: var(--step--2);
+    color: var(--ink-muted);
+}
+
+.affiliate-inner-box {
     flex-grow: 1;
 }
 
-.affiliate-svg{
-    padding-left: var(--space-s);
-    width: 3.5em;
-    height: 3.5em;
-    vertical-align: -0.125em;
+.affiliate-svg {
+    flex-shrink: 0;
+    padding-left: 0;
+    width: 2rem;
+    height: 2rem;
+    color: var(--accent-deep);
 }
 
-/* jank solutions */
-@media (min-width: 1024px) { /* hide on desktop */
+/* the two variants exist so the markup can differ per breakpoint */
+@media (min-width: 64rem) {
     .affiliate-mobile {
         display: none;
     }
 }
 
-@media (max-width: 1023px) { /* hide on mobile */
+@media (max-width: 63.99rem) {
     .affiliate-desktop {
         display: none;
     }

--- a/src/assets/css/components/button.css
+++ b/src/assets/css/components/button.css
@@ -1,0 +1,163 @@
+/* =========================================================================
+   Buttons
+   .button                 solid indigo, the default call to action
+   .button--accent         terracotta, used sparingly for the primary action
+   .button--outline        hairline outline on any surface
+   .button--ghost          text-only with an arrow, used inside cards/sections
+   .button--invert         for use on dark or photographic backgrounds
+   .button--small/--large  size modifiers
+   ========================================================================= */
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6em;
+    font-family: var(--font-display);
+    font-size: var(--step--1);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    line-height: 1;
+    text-decoration: none;
+    text-align: center;
+    cursor: pointer;
+    padding: 1.05em 1.9em;
+    border: 1px solid transparent;
+    border-radius: var(--radius-pill);
+    background-color: var(--brand-indigo);
+    color: var(--white);
+    transition: background-color var(--transition-base), color var(--transition-base),
+        border-color var(--transition-base), transform var(--transition-base),
+        box-shadow var(--transition-base);
+}
+
+.button:hover {
+    background-color: var(--brand-indigo-deep);
+    color: var(--white);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-s);
+}
+
+.button:active {
+    transform: translateY(0);
+    box-shadow: none;
+}
+
+.button[aria-disabled='true'],
+.button:disabled {
+    background-color: var(--border);
+    color: var(--ink-faint);
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+/* --- variants ---------------------------------------------------------- */
+
+.button--accent {
+    background-color: var(--accent);
+    color: var(--brand-indigo-ink);
+}
+
+.button--accent:hover {
+    background-color: var(--accent-deep);
+    color: var(--white);
+}
+
+.button--outline {
+    background-color: transparent;
+    border-color: var(--border-strong);
+    color: var(--ink-strong);
+}
+
+.button--outline:hover {
+    background-color: var(--ink-strong);
+    border-color: var(--ink-strong);
+    color: var(--surface);
+}
+
+.button--invert {
+    background-color: var(--white);
+    color: var(--brand-indigo-ink);
+}
+
+.button--invert:hover {
+    background-color: var(--accent);
+    color: var(--brand-indigo-ink);
+}
+
+.button--ghost {
+    background-color: transparent;
+    color: var(--ink-strong);
+    padding: 0.4em 0;
+    border-radius: 0;
+    border-bottom: 2px solid var(--accent);
+}
+
+.button--ghost:hover {
+    background-color: transparent;
+    color: var(--accent-deep);
+    border-bottom-color: var(--accent-deep);
+    transform: none;
+    box-shadow: none;
+}
+
+/* --- sizes -------------------------------------------------------------- */
+
+.button--small {
+    font-size: var(--step--2);
+    padding: 0.85em 1.4em;
+}
+
+.button--large {
+    font-size: var(--step-0);
+    padding: 1.1em 2.3em;
+}
+
+.button--block {
+    display: flex;
+    width: 100%;
+}
+
+/* --- arrow affordance ---------------------------------------------------- */
+
+.button__arrow {
+    width: 1em;
+    height: 1em;
+    flex-shrink: 0;
+    transition: transform var(--transition-base);
+}
+
+.button:hover .button__arrow {
+    transform: translateX(3px);
+}
+
+/* --- icon button (square, used for controls) ----------------------------- */
+
+.icon-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-circle);
+    background-color: transparent;
+    color: var(--ink);
+    cursor: pointer;
+    transition: background-color var(--transition-fade), color var(--transition-fade),
+        border-color var(--transition-fade);
+}
+
+.icon-button:hover {
+    background-color: var(--surface-alt);
+    border-color: var(--border-strong);
+    color: var(--accent-deep);
+}
+
+.icon-button svg {
+    width: 1.25rem;
+    height: 1.25rem;
+}

--- a/src/assets/css/components/card.css
+++ b/src/assets/css/components/card.css
@@ -1,0 +1,337 @@
+/* =========================================================================
+   Cards
+   .card              standard post card (image over stacked text)
+   .card--overlay     text sits on the image behind a scrim
+   .card--horizontal  image beside text, used for lists and related posts
+   .card--minimal     no image, just a rule and text
+   ========================================================================= */
+
+.card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background-color: transparent;
+}
+
+.card__media {
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--radius-m);
+    aspect-ratio: var(--card-media-ratio);
+    background-color: var(--surface-alt);
+    margin: 0;
+}
+
+/* the image shortcode wraps output in <figure>, so make it fill the frame */
+.card__media figure,
+.card__media picture {
+    position: static;
+    display: block;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+.card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+    transition: transform var(--transition-movement);
+}
+
+.card__media .bottom-left-text,
+.card__media figcaption {
+    display: none;
+}
+
+.card:hover .card__media img {
+    transform: scale(1.045);
+}
+
+.card__media--tall {
+    aspect-ratio: var(--card-media-ratio-tall);
+}
+
+.card__badge {
+    position: absolute;
+    top: var(--space-xs);
+    left: var(--space-xs);
+    z-index: 2;
+    background-color: color-mix(in srgb, var(--surface) 92%, transparent);
+    backdrop-filter: blur(6px);
+    color: var(--ink-strong);
+    border: 0;
+}
+
+.card__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    flex-grow: 1;
+    padding-top: var(--space-s);
+}
+
+.card__title {
+    font-size: var(--step-2);
+    line-height: var(--leading-heading);
+    letter-spacing: var(--tracking-tight);
+    margin: 0;
+}
+
+.card__title a {
+    color: inherit;
+    text-decoration: none;
+    background-image: linear-gradient(var(--accent), var(--accent));
+    background-repeat: no-repeat;
+    background-size: 0% 2px;
+    background-position: 0 100%;
+    transition: background-size var(--transition-base), color var(--transition-base);
+}
+
+.card__title a:hover {
+    color: var(--accent-deep);
+    background-size: 100% 2px;
+}
+
+/* Makes the whole card clickable while keeping the link text accessible */
+.card__title a::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+}
+
+.card__excerpt {
+    color: var(--ink-muted);
+    font-size: var(--step-0);
+    line-height: var(--leading-tight);
+    margin: 0;
+}
+
+.card__meta {
+    margin-top: auto;
+    padding-top: var(--space-xs);
+    font-size: var(--step--2);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    font-weight: var(--weight-semibold);
+}
+
+/* --- overlay card -------------------------------------------------------- */
+
+.card--overlay {
+    border-radius: var(--radius-m);
+    overflow: hidden;
+    min-height: 20rem;
+    justify-content: flex-end;
+}
+
+.card--overlay .card__media {
+    position: absolute;
+    inset: 0;
+    aspect-ratio: auto;
+    border-radius: 0;
+}
+
+.card--overlay .card__media::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, var(--scrim-strong) 0%, transparent 65%);
+}
+
+.card--overlay .card__body {
+    position: relative;
+    z-index: 2;
+    padding: var(--space-m);
+    flex-grow: 0;
+}
+
+.card--overlay .card__title,
+.card--overlay .card__title a,
+.card--overlay .card__excerpt,
+.card--overlay .card__meta {
+    color: var(--white);
+}
+
+.card--overlay .card__excerpt {
+    color: color-mix(in srgb, var(--white) 82%, transparent);
+}
+
+.card--overlay .eyebrow {
+    color: var(--brand-blush);
+}
+
+/* --- horizontal card ------------------------------------------------------ */
+
+.card--horizontal {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-m);
+}
+
+.card--horizontal .card__media {
+    flex: 0 0 clamp(6rem, 26%, 11rem);
+    aspect-ratio: 1 / 1;
+}
+
+.card--horizontal .card__body {
+    padding-top: 0;
+}
+
+.card--horizontal .card__title {
+    font-size: var(--step-1);
+}
+
+@media (max-width: 34rem) {
+    .card--horizontal {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .card--horizontal .card__media {
+        flex: none;
+        aspect-ratio: var(--card-media-ratio);
+    }
+
+    .card--horizontal .card__body {
+        padding-top: var(--space-s);
+    }
+}
+
+/* --- minimal card --------------------------------------------------------- */
+
+.card--minimal {
+    padding-top: var(--space-s);
+    border-top: 2px solid var(--ink-strong);
+}
+
+.card--minimal .card__body {
+    padding-top: 0;
+}
+
+/* --- boxed card (used for tools, resources, style guide swatches) ---------- */
+
+.card--boxed {
+    background-color: var(--surface-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-m);
+    padding: var(--space-m);
+    transition: border-color var(--transition-base), box-shadow var(--transition-base),
+        transform var(--transition-base);
+}
+
+.card--boxed:hover {
+    border-color: var(--border-strong);
+    box-shadow: var(--shadow-m);
+    transform: translateY(-3px);
+}
+
+.card--boxed .card__body {
+    padding-top: 0;
+}
+
+/* --- feature row (one large card beside a stack of small ones) ------------- */
+
+.feature-row {
+    display: grid;
+    gap: var(--space-m);
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.feature-row > * {
+    min-width: 0;
+}
+
+@media (min-width: 60rem) {
+    .feature-row {
+        grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+        align-items: stretch;
+    }
+
+    .feature-row__aside {
+        display: grid;
+        gap: var(--space-m);
+        align-content: start;
+    }
+
+    .feature-row__lead .card__media {
+        aspect-ratio: 16 / 10;
+    }
+
+    .feature-row__lead .card__title {
+        font-size: var(--step-4);
+    }
+}
+
+/* --- destination tile ------------------------------------------------------ */
+
+.tile {
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    overflow: hidden;
+    border-radius: var(--radius-m);
+    aspect-ratio: 4 / 5;
+    text-decoration: none;
+    background-color: var(--surface-alt);
+}
+
+.tile figure,
+.tile picture {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.tile img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+    transition: transform var(--transition-movement);
+}
+
+.tile figcaption,
+.tile .bottom-left-text {
+    display: none;
+}
+
+.tile::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, var(--scrim-strong) 0%, transparent 60%);
+    transition: opacity var(--transition-base);
+}
+
+.tile:hover img {
+    transform: scale(1.06);
+}
+
+.tile__label {
+    position: relative;
+    z-index: 2;
+    width: 100%;
+    padding: var(--space-s);
+    color: var(--white);
+    font-family: var(--font-display);
+    font-size: var(--step-1);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-tight);
+    line-height: var(--leading-heading);
+}
+
+.tile__count {
+    display: block;
+    font-size: var(--step--2);
+    font-weight: var(--weight-semibold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--brand-blush);
+}

--- a/src/assets/css/components/footer.css
+++ b/src/assets/css/components/footer.css
@@ -1,0 +1,149 @@
+/* =========================================================================
+   Site footer — multi-column, tinted, with the script wordmark up top
+   ========================================================================= */
+
+.footer {
+    margin-top: auto;
+    background-color: var(--footer-surface);
+    color: color-mix(in srgb, var(--footer-ink) 78%, transparent);
+    padding-block: var(--space-xl) var(--space-m);
+}
+
+.footer__inner {
+    width: 100%;
+    max-width: var(--width-page);
+    margin-inline: auto;
+    padding-inline: var(--gutter);
+}
+
+.footer__top {
+    display: grid;
+    gap: var(--space-l);
+    grid-template-columns: 1fr;
+    padding-bottom: var(--space-l);
+}
+
+@media (min-width: 48rem) {
+    .footer__top {
+        grid-template-columns: 1.4fr repeat(2, 1fr) auto;
+        gap: var(--space-m);
+    }
+}
+
+.footer__brand {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    max-width: 26rem;
+}
+
+.footer__wordmark {
+    font-family: var(--font-script);
+    font-size: var(--step-3);
+    line-height: 1.2;
+    color: var(--footer-ink);
+    text-decoration: none;
+}
+
+.footer__tagline {
+    font-size: var(--step--1);
+    line-height: var(--leading-tight);
+    margin: 0;
+}
+
+.footer__heading {
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--footer-heading);
+    margin: 0 0 var(--space-xs) 0;
+}
+
+.footer__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-2xs);
+    font-size: var(--step--1);
+}
+
+.footer__list a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.footer__list a:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
+.footer__bottom {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-s);
+    padding-top: var(--space-m);
+    border-top: 1px solid color-mix(in srgb, var(--footer-ink) 15%, transparent);
+    font-size: var(--step--2);
+}
+
+.footer__bottom a {
+    color: inherit;
+}
+
+.footer__bottom a:hover {
+    color: var(--accent);
+}
+
+.copyright {
+    margin: 0;
+    font-size: var(--step--2);
+}
+
+.footer__utilities {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
+}
+
+.rss-icon {
+    display: inline-flex;
+    width: 1.5rem;
+    height: 1.5rem;
+    color: inherit;
+}
+
+.rss-icon:hover {
+    color: var(--accent);
+}
+
+.rss-icon svg {
+    width: 100%;
+    height: 100%;
+}
+
+/* social links and the theme switch inherit the footer's own colours */
+.footer .social-menu a {
+    color: inherit;
+}
+
+.footer .social-menu a:hover {
+    color: var(--accent);
+}
+
+.footer .switch-wrapper .switch + .switch-btn {
+    background: color-mix(in srgb, var(--footer-ink) 25%, transparent);
+    border: 1px solid color-mix(in srgb, var(--footer-ink) 35%, transparent);
+}
+
+.footer .switch-wrapper .switch + .switch-btn::after {
+    background: var(--footer-ink);
+}
+
+.footer .switch-wrapper .icon {
+    color: var(--footer-surface);
+}

--- a/src/assets/css/components/hero.css
+++ b/src/assets/css/components/hero.css
@@ -1,0 +1,264 @@
+/* =========================================================================
+   Heroes
+   .hero              full-bleed photographic hero with a scrim (home)
+   .hero--compact     shorter version for landing pages
+   .page-hero         text-only header for pages
+   .post-hero         editorial header for a single post
+   ========================================================================= */
+
+.hero {
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    min-height: clamp(26rem, 74vh, 42rem);
+    overflow: hidden;
+    isolation: isolate;
+    background-color: var(--brand-indigo-ink);
+}
+
+.hero__media {
+    position: absolute;
+    inset: 0;
+    z-index: -2;
+}
+
+.hero__media figure,
+.hero__media picture {
+    position: static;
+    display: block;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+.hero__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+}
+
+.hero__media figcaption,
+.hero__media .bottom-left-text {
+    display: none;
+}
+
+.hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background:
+        linear-gradient(to top, var(--scrim-strong) 0%, color-mix(in srgb, var(--brand-indigo-ink) 20%, transparent) 55%, color-mix(in srgb, var(--brand-indigo-ink) 35%, transparent) 100%);
+}
+
+.hero__inner {
+    width: 100%;
+    max-width: var(--width-wide);
+    margin-inline: auto;
+    padding: var(--space-2xl) var(--gutter) var(--space-xl);
+    color: var(--white);
+}
+
+.hero__content {
+    max-width: 42rem;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+}
+
+.hero__title {
+    color: var(--white);
+    font-size: var(--step-7);
+    line-height: var(--leading-display);
+    letter-spacing: var(--tracking-display);
+    margin: 0;
+}
+
+.hero__script {
+    font-family: var(--font-script);
+    font-size: var(--step-3);
+    font-weight: var(--weight-regular);
+    letter-spacing: var(--tracking-normal);
+    color: var(--brand-blush);
+    display: block;
+    margin-bottom: var(--space-3xs);
+}
+
+.hero__lede {
+    font-size: var(--step-1);
+    line-height: var(--leading-tight);
+    color: color-mix(in srgb, var(--white) 88%, transparent);
+    max-width: 34rem;
+    margin: 0;
+}
+
+.hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    margin-top: var(--space-xs);
+}
+
+.hero--center {
+    align-items: center;
+    text-align: center;
+}
+
+.hero--center .hero__content {
+    max-width: 46rem;
+    margin-inline: auto;
+    align-items: center;
+}
+
+.hero--center .hero__lede {
+    margin-inline: auto;
+}
+
+.hero--center .hero__actions {
+    justify-content: center;
+}
+
+.hero--compact {
+    min-height: clamp(18rem, 46vh, 26rem);
+}
+
+/* photo credit line pinned to the hero corner */
+.hero__credit {
+    position: absolute;
+    right: var(--gutter);
+    bottom: var(--space-xs);
+    z-index: 2;
+    font-size: var(--step--2);
+    color: color-mix(in srgb, var(--white) 70%, transparent);
+}
+
+.hero__credit a {
+    color: inherit;
+}
+
+@media (max-width: 48rem) {
+    .hero__credit {
+        display: none;
+    }
+}
+
+/* =========================================================================
+   Page hero (no photograph)
+   ========================================================================= */
+
+.page-hero {
+    background-color: var(--surface-alt);
+    border-bottom: 1px solid var(--border);
+    padding-block: var(--space-xl) var(--space-l);
+    margin-bottom: var(--space-xl);
+}
+
+.page-hero__inner {
+    width: 100%;
+    max-width: var(--width-page);
+    margin-inline: auto;
+    padding-inline: var(--gutter);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    text-align: center;
+    align-items: center;
+}
+
+.page-hero__title {
+    margin: 0;
+    font-size: var(--step-5);
+}
+
+.page-hero__lede {
+    color: var(--ink-muted);
+    font-size: var(--step-1);
+    line-height: var(--leading-tight);
+    max-width: 44rem;
+    margin: 0;
+}
+
+/* =========================================================================
+   Post hero
+   ========================================================================= */
+
+.post-hero {
+    padding-block: var(--space-l) var(--space-m);
+}
+
+.post-hero__inner {
+    width: 100%;
+    max-width: calc(var(--width-content) + var(--gutter) * 2);
+    margin-inline: auto;
+    padding-inline: var(--gutter);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+    text-align: center;
+    align-items: center;
+}
+
+.post-hero__title {
+    margin: 0;
+    font-size: var(--step-5);
+    max-width: 20ch;
+}
+
+.post-hero__byline {
+    font-size: var(--step-1);
+    line-height: var(--leading-tight);
+    color: var(--ink-muted);
+    max-width: 46ch;
+    margin: 0;
+}
+
+.post-hero__meta {
+    justify-content: center;
+}
+
+.post-hero__figure {
+    width: 100%;
+    max-width: var(--width-wide);
+    margin-inline: auto;
+    padding-inline: var(--gutter);
+    margin-top: var(--space-m);
+}
+
+.post-hero__figure img {
+    width: 100%;
+    max-height: 70vh;
+    object-fit: cover;
+    border-radius: var(--radius-l);
+}
+
+/* breadcrumb above the title */
+.breadcrumb {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5em;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: var(--step--2);
+    font-weight: var(--weight-semibold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--ink-faint);
+}
+
+.breadcrumb a {
+    color: var(--accent-deep);
+    text-decoration: none;
+}
+
+.breadcrumb a:hover {
+    text-decoration: underline;
+}
+
+.breadcrumb li + li::before {
+    content: '/';
+    padding-right: 0.5em;
+    color: var(--border-strong);
+}

--- a/src/assets/css/components/navigation.css
+++ b/src/assets/css/components/navigation.css
@@ -1,0 +1,242 @@
+/* =========================================================================
+   Site header + navigation
+   Sticky, hairline-bottom bar. Logo left, links centre-right, utilities
+   far right. Collapses to a slide-down panel below 60rem.
+   ========================================================================= */
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background-color: color-mix(in srgb, var(--surface) 88%, transparent);
+    backdrop-filter: saturate(180%) blur(14px);
+    border-bottom: 1px solid var(--border);
+    transition: background-color var(--transition-base), border-color var(--transition-base);
+}
+
+.navigation {
+    display: flex;
+    align-items: center;
+    gap: var(--space-m);
+    min-height: var(--header-height);
+    width: 100%;
+    max-width: var(--width-wide);
+    margin-inline: auto;
+    padding-inline: var(--gutter);
+    padding-block: var(--space-2xs);
+}
+
+/* --- logo ---------------------------------------------------------------- */
+
+.site-logo {
+    display: block;
+    flex-shrink: 0;
+    width: 3.5rem;
+    line-height: 0;
+    text-decoration: none;
+}
+
+.site-logo svg {
+    width: 100%;
+    height: auto;
+    color: var(--ink-strong);
+}
+
+.site-logo svg .cls-1 {
+    fill: currentColor;
+}
+
+.site-logo svg .cls-2 {
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 0.6px;
+}
+
+.site-logo:hover svg {
+    color: var(--accent-deep);
+}
+
+/* --- primary menu -------------------------------------------------------- */
+
+.navigation-menu {
+    display: flex;
+    align-items: center;
+    gap: var(--space-m);
+    list-style: none;
+    margin: 0;
+    margin-inline-start: auto;
+    padding: 0;
+}
+
+.navigation-menu li {
+    margin: 0;
+    padding: 0;
+}
+
+.navigation-menu a {
+    position: relative;
+    display: inline-block;
+    font-family: var(--font-display);
+    font-size: var(--step--1);
+    font-weight: var(--weight-semibold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    text-decoration: none;
+    color: var(--ink-strong);
+    padding-block: 0.35em;
+}
+
+.navigation-menu a::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 2px;
+    background-color: var(--accent);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform var(--transition-base);
+}
+
+.navigation-menu a:hover {
+    color: var(--accent-deep);
+}
+
+.navigation-menu a:hover::after,
+.navigation-menu a[aria-current='page']::after {
+    transform: scaleX(1);
+}
+
+.navigation-menu a[aria-current='page'] {
+    color: var(--accent-deep);
+}
+
+/* --- right-hand utilities ------------------------------------------------ */
+
+.navigation-utilities {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-inline-start: var(--space-s);
+    padding-inline-start: var(--space-s);
+    border-inline-start: 1px solid var(--border);
+}
+
+/* --- mobile toggle ------------------------------------------------------- */
+
+.navigation-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    margin-inline-start: auto;
+    padding: 0.6em 1em;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--ink-strong);
+    cursor: pointer;
+}
+
+.navigation-toggle__bars {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 3px;
+    width: 1rem;
+}
+
+.navigation-toggle__bars span {
+    display: block;
+    height: 2px;
+    background-color: currentColor;
+    border-radius: 2px;
+    transition: transform var(--transition-base), opacity var(--transition-base);
+}
+
+.navigation-toggle[aria-expanded='true'] .navigation-toggle__bars span:nth-child(1) {
+    transform: translateY(5px) rotate(45deg);
+}
+
+.navigation-toggle[aria-expanded='true'] .navigation-toggle__bars span:nth-child(2) {
+    opacity: 0;
+}
+
+.navigation-toggle[aria-expanded='true'] .navigation-toggle__bars span:nth-child(3) {
+    transform: translateY(-5px) rotate(-45deg);
+}
+
+@media (max-width: 60rem) {
+    .navigation-toggle {
+        display: inline-flex;
+    }
+
+    .navigation-panel {
+        display: none;
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--space-s);
+        padding: var(--space-m) var(--gutter) var(--space-l);
+        background-color: var(--surface);
+        border-bottom: 1px solid var(--border);
+        box-shadow: var(--shadow-m);
+    }
+
+    .navigation-panel[data-open='true'] {
+        display: flex;
+    }
+
+    .navigation-menu {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0;
+        margin-inline-start: 0;
+    }
+
+    .navigation-menu li + li {
+        border-top: 1px solid var(--border);
+    }
+
+    .navigation-menu a {
+        display: block;
+        font-size: var(--step-1);
+        letter-spacing: var(--tracking-tight);
+        text-transform: none;
+        font-weight: var(--weight-bold);
+        padding-block: var(--space-s);
+    }
+
+    .navigation-menu a::after {
+        display: none;
+    }
+
+    .navigation-utilities {
+        margin-inline-start: 0;
+        padding-inline-start: 0;
+        border-inline-start: 0;
+        justify-content: space-between;
+        padding-top: var(--space-xs);
+        border-top: 1px solid var(--border);
+    }
+}
+
+@media (min-width: 60.0625rem) {
+    .navigation-panel {
+        display: flex;
+        align-items: center;
+        gap: var(--space-m);
+        margin-inline-start: auto;
+    }
+}

--- a/src/assets/css/components/newsletter.css
+++ b/src/assets/css/components/newsletter.css
@@ -1,0 +1,145 @@
+/* =========================================================================
+   Newsletter / subscribe band + form controls
+   ========================================================================= */
+
+.newsletter {
+    background-color: var(--accent-wash);
+    border-radius: var(--radius-l);
+    padding: var(--space-l) var(--space-m-l);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-xs);
+}
+
+.newsletter--invert {
+    background-color: var(--surface-invert);
+    color: var(--ink-invert);
+}
+
+.newsletter--invert .newsletter__title,
+.newsletter--invert .newsletter__lede {
+    color: var(--ink-invert);
+}
+
+.newsletter--invert .eyebrow {
+    color: var(--brand-blush);
+}
+
+.newsletter__title {
+    font-size: var(--step-4);
+    margin: 0;
+    max-width: 18ch;
+}
+
+.newsletter__lede {
+    color: var(--ink-muted);
+    max-width: 46ch;
+    margin: 0;
+}
+
+.newsletter__form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs);
+    width: 100%;
+    max-width: 30rem;
+    margin-top: var(--space-xs);
+}
+
+.newsletter__form .field {
+    flex: 1 1 14rem;
+    margin: 0;
+}
+
+.newsletter__note {
+    font-size: var(--step--2);
+    color: var(--ink-muted);
+    margin: 0;
+}
+
+/* =========================================================================
+   Form controls
+   ========================================================================= */
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3xs);
+    text-align: left;
+}
+
+.field__label {
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--ink-muted);
+}
+
+.field__hint {
+    font-size: var(--step--2);
+    color: var(--ink-faint);
+}
+
+.input,
+.textarea,
+.select {
+    width: 100%;
+    background-color: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-pill);
+    padding: 0.95em 1.4em;
+    font-size: var(--step--1);
+    line-height: 1.2;
+    transition: border-color var(--transition-fade), box-shadow var(--transition-fade);
+}
+
+.textarea {
+    border-radius: var(--radius-m);
+    min-height: 8rem;
+    resize: vertical;
+}
+
+.select {
+    appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+        linear-gradient(135deg, currentColor 50%, transparent 50%);
+    background-position: calc(100% - 1.35em) 50%, calc(100% - 1.05em) 50%;
+    background-size: 0.35em 0.35em, 0.35em 0.35em;
+    background-repeat: no-repeat;
+    padding-right: 2.75em;
+}
+
+.input::placeholder,
+.textarea::placeholder {
+    color: var(--ink-faint);
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.input:disabled,
+.textarea:disabled,
+.select:disabled {
+    background-color: var(--surface-alt);
+    color: var(--ink-faint);
+    cursor: not-allowed;
+}
+
+.input--invalid {
+    border-color: var(--signal-danger);
+}
+
+.field__error {
+    font-size: var(--step--2);
+    color: var(--signal-danger);
+}

--- a/src/assets/css/components/prose.css
+++ b/src/assets/css/components/prose.css
@@ -1,0 +1,365 @@
+/* =========================================================================
+   Prose — long-form article body.
+
+   Built as a named-line grid so plain markdown needs no wrapper divs:
+   text sits in the `content` column, figures and embeds widen out into
+   the `wide` column, and anything marked .bleed spans `full`.
+   ========================================================================= */
+
+.prose {
+    display: grid;
+    grid-template-columns:
+        [full-start] minmax(var(--gutter), 1fr)
+        [wide-start] minmax(0, calc((var(--width-wide) - var(--width-content)) / 2))
+        [content-start] min(var(--width-content), 100% - var(--gutter) * 2) [content-end]
+        minmax(0, calc((var(--width-wide) - var(--width-content)) / 2)) [wide-end]
+        minmax(var(--gutter), 1fr) [full-end];
+    font-size: var(--step-0);
+    line-height: var(--leading-body);
+    color: var(--ink);
+}
+
+.prose > * {
+    grid-column: content;
+    min-width: 0;
+}
+
+.prose > * + * {
+    margin-top: var(--space-m);
+}
+
+/* --- headings ------------------------------------------------------------ */
+
+.prose > h2 {
+    font-size: var(--step-3);
+    margin-top: var(--space-xl);
+    padding-top: var(--space-s);
+    border-top: 1px solid var(--divider);
+    scroll-margin-top: calc(var(--header-height) + var(--space-m));
+}
+
+.prose > h3 {
+    font-size: var(--step-2);
+    margin-top: var(--space-l);
+    scroll-margin-top: calc(var(--header-height) + var(--space-m));
+}
+
+.prose > h4 {
+    font-size: var(--step-1);
+    margin-top: var(--space-m-l);
+}
+
+.prose > h5,
+.prose > h6 {
+    margin-top: var(--space-m);
+}
+
+.prose > h2 + *,
+.prose > h3 + *,
+.prose > h4 + * {
+    margin-top: var(--space-s);
+}
+
+/* --- body copy ----------------------------------------------------------- */
+
+.prose p {
+    margin: 0;
+}
+
+/* only inline prose links get the underline treatment — component links
+   (card titles, buttons, tags, tiles) keep their own styling */
+.prose :is(p, li, dd, dt, td, th, blockquote, figcaption) a:not([class]) {
+    color: var(--link);
+    text-decoration: underline;
+    text-decoration-color: var(--link-underline);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.18em;
+}
+
+.prose :is(p, li, dd, dt, td, th, blockquote, figcaption) a:not([class]):hover {
+    color: var(--link-hover);
+    text-decoration-color: currentColor;
+}
+
+/* --- lists --------------------------------------------------------------- */
+
+.prose ul,
+.prose ol {
+    margin-block: 0;
+    padding-inline-start: 1.35em;
+}
+
+.prose li + li {
+    margin-top: var(--space-2xs);
+}
+
+.prose li::marker {
+    color: var(--accent-deep);
+    font-weight: var(--weight-bold);
+}
+
+.prose ul ul,
+.prose ul ol,
+.prose ol ul,
+.prose ol ol {
+    margin-top: var(--space-2xs);
+}
+
+/* --- quotes -------------------------------------------------------------- */
+
+.prose blockquote:not([class]) {
+    margin: 0;
+    padding: var(--space-s) 0 var(--space-s) var(--space-m);
+    border-left: 3px solid var(--accent);
+    font-size: var(--step-1);
+    line-height: var(--leading-tight);
+    color: var(--ink-strong);
+    font-style: italic;
+}
+
+.prose blockquote:not([class]) p + p {
+    margin-top: var(--space-xs);
+}
+
+.prose blockquote:not([class]) cite {
+    display: block;
+    margin-top: var(--space-xs);
+    font-size: var(--step--1);
+    font-style: normal;
+    color: var(--ink-muted);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+}
+
+/* --- figures, images and embeds ------------------------------------------ */
+
+.prose > figure,
+.prose > .oembed,
+.prose > p:has(> picture),
+.prose > p:has(> img),
+.prose > .wide {
+    grid-column: wide;
+    margin-top: var(--space-l);
+    margin-bottom: var(--space-l);
+}
+
+.prose > figure + *,
+.prose > .oembed + * {
+    margin-top: 0;
+}
+
+.prose figure img {
+    width: 100%;
+    border-radius: var(--radius-l);
+}
+
+.prose figcaption {
+    text-align: center;
+    margin-inline: auto;
+    color: var(--ink-muted);
+    font-size: var(--step--1);
+}
+
+.prose > .bleed {
+    grid-column: full;
+}
+
+/* .wide blocks stay inside the page shell so card grids line up with the
+   rest of the site rather than running to the viewport edge */
+.prose > .wide {
+    width: 100%;
+    max-width: var(--width-page);
+    margin-inline: auto;
+}
+
+.prose iframe,
+.prose lite-youtube {
+    width: 100%;
+    border-radius: var(--radius-m);
+}
+
+/* --- tables --------------------------------------------------------------- */
+
+.prose > table {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-m);
+    margin-top: var(--space-l);
+}
+
+/* below the reading column width a wide table scrolls rather than squashing */
+@media (max-width: 48rem) {
+    .prose > table {
+        display: block;
+        overflow-x: auto;
+        white-space: normal;
+    }
+}
+
+/* --- code ----------------------------------------------------------------- */
+
+.prose > pre {
+    margin-top: var(--space-l);
+}
+
+/* --- horizontal rule ------------------------------------------------------ */
+
+.prose > hr {
+    margin-block: var(--space-xl);
+}
+
+/* --- notices, affiliate boxes and other injected blocks ------------------- */
+
+.prose > .notice {
+    max-width: none;
+    margin-top: var(--space-l);
+    margin-bottom: var(--space-l);
+}
+
+/* Third-party widgets (GetYourGuide etc.) drop in as bare divs */
+.prose > div[data-gyg-widget],
+.prose > .widget {
+    margin-top: var(--space-l);
+}
+
+/* =========================================================================
+   Table of contents
+   Markdown authors write "### Table of Contents" followed by a list; the
+   .toc class can be added around it, or use .toc on a wrapping div.
+   ========================================================================= */
+
+.toc {
+    background-color: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-m);
+    padding: var(--space-m);
+}
+
+.toc > :first-child {
+    margin-top: 0;
+}
+
+.toc h2,
+.toc h3,
+.toc h4 {
+    font-size: var(--step--1);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+    font-weight: var(--weight-bold);
+    color: var(--ink-muted);
+    border: 0;
+    padding: 0;
+    margin: 0 0 var(--space-xs) 0;
+}
+
+.toc ul,
+.toc ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-2xs);
+}
+
+.toc li + li {
+    margin-top: 0;
+}
+
+.toc a {
+    display: block;
+    text-decoration: none;
+    font-weight: var(--weight-medium);
+    color: var(--ink-strong);
+    padding-left: var(--space-s);
+    border-left: 2px solid var(--border-strong);
+    transition: border-color var(--transition-fade), color var(--transition-fade),
+        padding-left var(--transition-fade);
+}
+
+.toc a:hover {
+    color: var(--accent-deep);
+    border-left-color: var(--accent);
+    padding-left: calc(var(--space-s) + 3px);
+}
+
+/* =========================================================================
+   Callouts — hand-written boxes for tips, packing lists, budgets
+   ========================================================================= */
+
+.callout {
+    background-color: var(--surface-alt);
+    border-radius: var(--radius-m);
+    padding: var(--space-m);
+    border: 1px solid var(--border);
+}
+
+.callout__title {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    font-family: var(--font-display);
+    font-size: var(--step--1);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--accent-deep);
+    margin: 0 0 var(--space-2xs) 0;
+}
+
+.callout > :last-child {
+    margin-bottom: 0;
+}
+
+.callout--accent {
+    background-color: var(--accent-wash);
+    border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.callout--invert {
+    background-color: var(--surface-invert);
+    border-color: transparent;
+    color: var(--ink-invert);
+}
+
+.callout--invert .callout__title {
+    color: var(--brand-blush);
+}
+
+/* =========================================================================
+   Post footer pieces
+   ========================================================================= */
+
+.post-footer {
+    width: 100%;
+    max-width: calc(var(--width-content) + var(--gutter) * 2);
+    margin-inline: auto;
+    padding-inline: var(--gutter);
+    margin-top: var(--space-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-l);
+}
+
+.post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+/* Affiliate disclosure that sits under the post header */
+.affiliate {
+    max-width: none;
+    text-align: center;
+    background-color: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-m);
+    padding: var(--space-xs) var(--space-s);
+    font-size: var(--step--1);
+    color: var(--ink-muted);
+}
+
+.affiliate a {
+    color: var(--accent-deep);
+}

--- a/src/assets/css/components/social-icons.css
+++ b/src/assets/css/components/social-icons.css
@@ -1,48 +1,68 @@
-/* .social span,
-.social a {
-    padding: var(--space-3xs) var(--space-2xs);
-    text-decoration: none;
-    margin-left: var(--space-2xs);
-    background-color: var(--link);
-    color: var(--background);
-    border-radius: var(--step--1);
-    display: inline-block;
-}
-
-.social a:hover,
-.social a.current {
-    background-color: var(--foreground);
-    color: var(--background);
-}
-
-.social span.disabled {
-    background-color: var(--background-soft);
-    color: var(--foreground-soft);
-    cursor: not-allowed;
-}
- */
+/* =========================================================================
+   Social links
+   ========================================================================= */
 
 .social-menu {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
     list-style: none;
-    border: 0;
     margin: 0;
     padding: 0;
-    display: flex;
-    gap: var(--space-s-m);
-    text-align: right;
 }
 
 .social-menu li {
     margin: 0;
     padding: 0;
-    text-align: right;
 }
 
-.social-menu li a {
+.social-menu li p {
+    margin: 0;
+}
+
+.social-menu a {
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-semibold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
     text-decoration: none;
-    letter-spacing: var(--tracking-s);
+    color: var(--ink-muted);
+    transition: color var(--transition-fade);
 }
 
-.social-menu li a:focus {
-    outline-offset: 0.6ch;
+.social-menu a:hover {
+    color: var(--accent-deep);
+}
+
+/* icon variant, used in the footer */
+.social-menu--icons a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+    border-radius: var(--radius-circle);
+    color: inherit;
+}
+
+.social-menu--icons a:hover {
+    background-color: var(--accent);
+    border-color: var(--accent);
+    color: var(--brand-indigo-ink);
+}
+
+.social-menu--icons svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.social-icon {
+    color: var(--link);
+}
+
+.social-icon:hover {
+    color: var(--link-hover);
+    text-decoration: none;
 }

--- a/src/assets/css/components/styleguide.css
+++ b/src/assets/css/components/styleguide.css
@@ -1,0 +1,416 @@
+/* =========================================================================
+   Style guide — chrome for the /styleguide/ page only.
+   Deliberately plain so the components on show do the talking.
+   ========================================================================= */
+
+.sg {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-l);
+    align-items: start;
+}
+
+/* grid items default to min-width:auto, which lets wide code blocks and
+   tables stretch the track instead of scrolling inside it */
+.sg > * {
+    min-width: 0;
+}
+
+@media (min-width: 64rem) {
+    .sg {
+        grid-template-columns: 15rem minmax(0, 1fr);
+        gap: var(--space-xl);
+    }
+}
+
+/* --- sidebar navigation --------------------------------------------------- */
+
+.sg-nav {
+    position: sticky;
+    top: calc(var(--header-height) + var(--space-m));
+    align-self: start;
+    border-left: 2px solid var(--border);
+    padding-left: var(--space-s);
+    max-height: calc(100vh - var(--header-height) - var(--space-xl));
+    overflow-y: auto;
+}
+
+.sg-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-3xs);
+}
+
+.sg-nav a {
+    display: block;
+    font-size: var(--step--1);
+    font-weight: var(--weight-medium);
+    color: var(--ink-muted);
+    text-decoration: none;
+    padding-block: 0.15em;
+}
+
+.sg-nav a:hover {
+    color: var(--accent-deep);
+}
+
+.sg-nav__heading {
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin: var(--space-s) 0 var(--space-3xs);
+}
+
+.sg-nav__heading:first-child {
+    margin-top: 0;
+}
+
+/* on narrow screens the sidebar becomes a compact wrap of chips so it does
+   not push the content a full screen down */
+@media (max-width: 63.99rem) {
+    .sg-nav {
+        position: static;
+        max-height: none;
+        border-left: 0;
+        padding: var(--space-s) var(--space-m);
+        background-color: var(--surface-alt);
+        border-radius: var(--radius-m);
+    }
+
+    .sg-nav ul {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2xs);
+    }
+
+    .sg-nav a {
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-pill);
+        padding: 0.3em 0.9em;
+        background-color: var(--surface);
+        font-size: var(--step--2);
+    }
+
+    .sg-nav__heading {
+        margin-top: var(--space-s);
+        margin-bottom: var(--space-2xs);
+    }
+}
+
+/* --- a documented section ------------------------------------------------- */
+
+.sg-section {
+    scroll-margin-top: calc(var(--header-height) + var(--space-m));
+    padding-bottom: var(--space-l);
+    border-bottom: 1px solid var(--divider);
+}
+
+.sg-section + .sg-section {
+    padding-top: var(--space-l);
+}
+
+.sg-section__title {
+    font-size: var(--step-3);
+    margin: 0 0 var(--space-2xs);
+}
+
+.sg-section__intro {
+    color: var(--ink-muted);
+    max-width: var(--measure);
+    margin: 0 0 var(--space-m);
+}
+
+/* --- a single story: label, canvas, code --------------------------------- */
+
+.sg-story {
+    margin-top: var(--space-m);
+}
+
+.sg-story__label {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--space-2xs);
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-bottom: var(--space-2xs);
+}
+
+.sg-story__note {
+    font-family: var(--font-body);
+    font-size: var(--step--1);
+    font-weight: var(--weight-regular);
+    letter-spacing: var(--tracking-normal);
+    text-transform: none;
+    color: var(--ink-muted);
+}
+
+.sg-canvas {
+    background-color: var(--surface);
+    background-image:
+        linear-gradient(45deg, var(--border) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--border) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--border) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--border) 75%);
+    background-size: 16px 16px;
+    background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-m);
+    padding: var(--space-m);
+    overflow: hidden;
+}
+
+/* opaque inner so components sit on a real surface, not the checkerboard */
+.sg-canvas > .sg-canvas__inner {
+    background-color: var(--surface);
+    border-radius: var(--radius-s);
+    padding: var(--space-m);
+}
+
+.sg-canvas--flush {
+    padding: 0;
+    background-image: none;
+}
+
+.sg-canvas--flush > .sg-canvas__inner {
+    padding: 0;
+    border-radius: 0;
+}
+
+.sg-canvas--tinted > .sg-canvas__inner {
+    background-color: var(--surface-alt);
+}
+
+.sg-canvas--dark > .sg-canvas__inner {
+    background-color: var(--surface-invert);
+    color: var(--ink-invert);
+}
+
+.sg-code {
+    margin: 0;
+    margin-top: var(--space-2xs);
+    background-color: var(--code-background);
+    color: var(--code-default);
+    border-radius: var(--radius-s);
+    padding: var(--space-s) var(--space-m);
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+    line-height: 1.7;
+    overflow-x: auto;
+    white-space: pre;
+}
+
+.sg-code code {
+    background: none;
+    padding: 0;
+    color: inherit;
+    font-size: inherit;
+}
+
+/* --- token tables --------------------------------------------------------- */
+
+.sg-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--step--1);
+}
+
+.sg-table th,
+.sg-table td {
+    text-align: left;
+    padding: var(--space-2xs) var(--space-xs);
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+}
+
+.sg-table thead th {
+    font-size: var(--step--2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+    color: var(--ink-faint);
+    border-bottom: 2px solid var(--border-strong);
+}
+
+.sg-table code {
+    font-size: var(--step--2);
+    white-space: nowrap;
+}
+
+/* --- colour swatches ------------------------------------------------------ */
+
+.sg-swatches {
+    display: grid;
+    gap: var(--space-s);
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 12.5rem), 1fr));
+}
+
+.sg-swatch {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-m);
+    overflow: hidden;
+    background-color: var(--surface-raised);
+}
+
+.sg-swatch__chip {
+    height: 5rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.sg-swatch__meta {
+    padding: var(--space-xs);
+    display: grid;
+    gap: 0.1em;
+}
+
+.sg-swatch__name {
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+    color: var(--ink-strong);
+    overflow-wrap: anywhere;
+}
+
+.sg-swatch__value {
+    font-size: var(--step--2);
+    color: var(--ink-faint);
+}
+
+/* --- type specimens ------------------------------------------------------- */
+
+.sg-specimen {
+    display: grid;
+    gap: var(--space-s);
+}
+
+.sg-specimen__row {
+    display: grid;
+    gap: var(--space-3xs);
+    padding-bottom: var(--space-s);
+    border-bottom: 1px dashed var(--border);
+}
+
+.sg-specimen__row:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
+.sg-specimen__meta {
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+    color: var(--ink-faint);
+}
+
+.sg-specimen__sample {
+    margin: 0;
+    line-height: var(--leading-heading);
+    color: var(--ink-strong);
+    overflow-wrap: anywhere;
+}
+
+/* --- spacing ruler -------------------------------------------------------- */
+
+.sg-space {
+    display: grid;
+    gap: var(--space-2xs);
+}
+
+.sg-space__row {
+    display: grid;
+    grid-template-columns: 8rem 1fr;
+    align-items: center;
+    gap: var(--space-s);
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+    color: var(--ink-muted);
+}
+
+.sg-space__bar {
+    height: 1rem;
+    background-color: var(--accent-soft);
+    border-radius: var(--radius-xs);
+}
+
+/* --- misc ----------------------------------------------------------------- */
+
+.sg-radius-grid,
+.sg-shadow-grid {
+    display: grid;
+    gap: var(--space-s);
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 9rem), 1fr));
+}
+
+.sg-radius-demo {
+    aspect-ratio: 3 / 2;
+    background-color: var(--brand-indigo);
+    display: grid;
+    place-items: center;
+    color: var(--white);
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+}
+
+.sg-shadow-demo {
+    aspect-ratio: 3 / 2;
+    background-color: var(--surface-raised);
+    border-radius: var(--radius-m);
+    display: grid;
+    place-items: center;
+    font-family: var(--font-mono);
+    font-size: var(--step--2);
+    color: var(--ink-muted);
+}
+
+.sg-do-dont {
+    display: grid;
+    gap: var(--space-s);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+}
+
+.sg-do,
+.sg-dont {
+    border-radius: var(--radius-m);
+    padding: var(--space-s) var(--space-m);
+    border: 1px solid var(--border);
+    border-left-width: 4px;
+}
+
+.sg-do {
+    border-left-color: var(--signal-success);
+    background-color: color-mix(in srgb, var(--signal-success) 7%, var(--surface));
+}
+
+.sg-dont {
+    border-left-color: var(--signal-danger);
+    background-color: color-mix(in srgb, var(--signal-danger) 7%, var(--surface));
+}
+
+.sg-do h4,
+.sg-dont h4 {
+    font-size: var(--step--1);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+    margin: 0 0 var(--space-3xs);
+}
+
+.sg-do h4 {
+    color: var(--signal-success);
+}
+
+.sg-dont h4 {
+    color: var(--signal-danger);
+}
+
+.sg-do p,
+.sg-dont p {
+    margin: 0;
+    font-size: var(--step--1);
+    color: var(--ink-muted);
+}

--- a/src/assets/css/components/switch-darkmode.css
+++ b/src/assets/css/components/switch-darkmode.css
@@ -1,21 +1,29 @@
-.switch-wrapper .switch + .switch-btn {
-	background: var(--foreground);
-	border-radius: 2em;
-	padding: 6px;
-	transition: all 0.4s ease;
-	display: block;
-	width: 3.5em;
-	height: 2em;
-	position: relative;
-	cursor: pointer;
-	user-select: none;
+/* =========================================================================
+   Light / dark theme switch
+   ========================================================================= */
+
+.switch-wrapper .switch {
+	display: none;
 }
 
-.switch-wrapper .switch + .switch-btn::before, 
+.switch-wrapper .switch + .switch-btn {
+	position: relative;
+	display: block;
+	width: 3.5rem;
+	height: 2rem;
+	padding: 6px;
+	background: var(--border-strong);
+	border-radius: var(--radius-pill);
+	cursor: pointer;
+	user-select: none;
+	transition: background var(--transition-base);
+}
+
+.switch-wrapper .switch + .switch-btn::before,
 .switch-wrapper .switch + .switch-btn::after {
 	position: relative;
 	display: block;
-	content: "";
+	content: '';
 	height: 100%;
 }
 
@@ -26,38 +34,31 @@
 
 .switch-wrapper .switch + .switch-btn::after {
 	left: 0;
-	border-radius: 50%;
-	background: var(--background);
 	width: unset;
-	aspect-ratio: 1/1;
-	transition: all 0.2s ease;
-}
-
-.switch-wrapper .switch:checked + .switch-btn {
-	background: var(--foreground);
+	aspect-ratio: 1 / 1;
+	border-radius: var(--radius-circle);
+	background: var(--surface);
+	box-shadow: var(--shadow-xs);
+	transition: transform var(--transition-base), background var(--transition-base);
 }
 
 .switch-wrapper .switch-btn.switch-button-on::after {
 	transform: translateX(106%) !important;
-	background: var(--background);
 }
 
 .switch-wrapper .icon {
-	width: 20px;
 	position: absolute;
 	top: 50%;
 	transform: translateY(-50%);
-	color: var(--background);
+	width: 0.9rem;
+	height: 0.9rem;
+	color: var(--surface);
 }
 
 .switch-wrapper .icon-sun {
-	left: 12%;
+	left: 13%;
 }
 
 .switch-wrapper .icon-moon {
-	right: 12%;
-}
-
-.switch-wrapper .switch {
-	display: none;
+	right: 13%;
 }

--- a/src/assets/css/components/switch-il8n.css
+++ b/src/assets/css/components/switch-il8n.css
@@ -1,22 +1,45 @@
-.switch-language a,
-.switch-language span {
-    padding: var(--space-3xs) var(--space-2xs);
-    text-decoration: none;
-    margin-left: var(--space-2xs);
-    background-color: var(--link);
-    color: var(--background);
-    border-radius: var(--step--1);
-    display: inline-block;
+/* =========================================================================
+   Language switch
+   ========================================================================= */
+
+.switch-language {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3xs);
 }
 
-.switch-language a:hover,
+.switch-language a,
+.switch-language span {
+    display: inline-block;
+    padding: 0.35em 0.8em;
+    border-radius: var(--radius-pill);
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    text-decoration: none;
+    color: var(--ink-muted);
+    background-color: transparent;
+    border: 1px solid var(--border);
+    transition: background-color var(--transition-fade), color var(--transition-fade),
+        border-color var(--transition-fade);
+}
+
+.switch-language a:hover {
+    color: var(--accent-deep);
+    border-color: var(--accent-soft);
+    background-color: var(--accent-wash);
+}
+
 .switch-language a.current {
-    background-color: var(--foreground);
-    color: var(--background);
+    background-color: var(--surface-invert);
+    border-color: transparent;
+    color: var(--ink-invert);
 }
 
 .switch-language span.disabled {
-    background-color: var(--background-soft);
-    color: var(--foreground-soft);
+    color: var(--ink-faint);
+    border-style: dashed;
     cursor: not-allowed;
 }

--- a/src/assets/css/components/syntax.css
+++ b/src/assets/css/components/syntax.css
@@ -18,18 +18,23 @@ pre[class*="language-"] {
 }
 
 code[class*="language-"] {
-    padding-right: var(--space-s-l);
+    padding-right: var(--space-m);
+}
+
+pre[class*="language-"] {
+    font-size: var(--step--1);
+    line-height: 1.6;
 }
 
 [class*="language-"]::selection,
 [class*="language-"] *::selection {
-    background: var(--nord13);
-    color: var(--nord0);
+    background: var(--accent-soft);
+    color: var(--brand-indigo-ink);
 }
 
 /* code blocks */
 pre[class*="language-"] {
-    padding: var(--space-s-l);
+    padding: var(--space-m);
     overflow: auto;
 }
 

--- a/src/assets/css/reset.css
+++ b/src/assets/css/reset.css
@@ -13,6 +13,8 @@ h1,
 h2,
 h3,
 h4,
+h5,
+h6,
 p,
 figure,
 blockquote,
@@ -35,8 +37,7 @@ html:focus-within {
 /* Set core body defaults */
 body {
 	min-height: 100vh;
-	/*text-rendering: optimizeSpeed; - this can break safari thing*/
-	line-height: 1.5;
+	line-height: var(--leading-body);
 }
 
 /* A elements that don't have a class get default styles */
@@ -46,18 +47,17 @@ a:not([class]) {
 
 /* Make images easier to work with */
 img,
-picture,
-svg {
-	width: 100%;
+picture {
+	max-width: 100%;
 	height: auto;
 	display: block;
 }
 
-/* Fix svg in Firefox */
+/* SVGs size from their own attributes / component rules rather than
+   being force-stretched — icons and the logo both need to work. */
 svg {
-	overflow: visible;
-	width: 100%;
-	height: 100%
+	display: block;
+	max-width: 100%;
 }
 
 /* Inherit fonts for inputs and buttons */
@@ -66,4 +66,13 @@ button,
 textarea,
 select {
 	font: inherit;
+	color: inherit;
+}
+
+/* Remove list styling where a class is doing the work */
+ul[class],
+ol[class] {
+	list-style: none;
+	margin: 0;
+	padding: 0;
 }

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -237,6 +237,36 @@ figure > figcaption {
     max-width: var(--measure);
 }
 
+/* A captioned figure is a two-row grid: image on top, caption below. The photo
+   credit chip becomes a grid item sharing the image cell, so it stays pinned
+   inside the photograph however many lines the caption runs to. Figures
+   without a caption (cards, tiles, heroes) never carry a chip and are left as
+   plain blocks, where the absolute positioning below still applies. */
+figure:has(> figcaption) {
+    display: grid;
+    grid-template-rows: auto auto;
+}
+
+figure:has(> figcaption) > picture,
+figure:has(> figcaption) > img,
+figure:has(> figcaption) > .bottom-left-text {
+    grid-row: 1;
+    grid-column: 1;
+}
+
+figure:has(> figcaption) > figcaption {
+    grid-row: 2;
+    grid-column: 1;
+}
+
+figure:has(> figcaption) > .bottom-left-text {
+    position: relative;
+    inset: auto;
+    align-self: end;
+    justify-self: end;
+    margin: var(--space-s);
+}
+
 .oembed-youtube,
 .oembed-vimeo {
     border-radius: var(--radius-m);

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -1,84 +1,64 @@
-@media (prefers-reduced-motion) {
-	* {
-		transition: none !important;
+/* =========================================================================
+   Base — element defaults, layout shells and utilities.
+   Components live in ./components/*.css
+   ========================================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
 	}
 }
 
 html {
-	overflow-y: scroll;
+    overflow-y: scroll;
+    scroll-padding-top: calc(var(--header-height) + var(--space-m));
 }
 
 body {
-    background-color: var(--background);
-    color: var(--foreground);
-    font-family: var(--font-base);
+    background-color: var(--surface);
+    color: var(--ink);
+    font-family: var(--font-body);
     font-size: var(--step-0);
-    line-height: 1.4;
-    letter-spacing: var(--tracking);
-    transition: background var(--transition-base), color var(--transition-base);
+    font-weight: var(--weight-regular);
+    line-height: var(--leading-body);
+    letter-spacing: var(--tracking-normal);
+    font-synthesis-weight: none;
+    -webkit-font-smoothing: antialiased;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    transition: background-color var(--transition-base), color var(--transition-base);
 }
 
-[x-cloak] { 
-    display: none !important; 
+[x-cloak] {
+    display: none !important;
 }
 
 ::selection {
-    background: var(--foreground);
-    color: var(--background);
+    background: var(--accent-soft);
+    color: var(--brand-indigo-ink);
 }
 
-:focus {
-    transition: var(--transition-base);
-    outline: var(--focus-outline);
-    outline-offset: 0.3ch;
-    border-radius: var(--border-radius);
-    text-decoration: none;
+:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: var(--focus-offset);
+    border-radius: var(--radius-xs);
 }
 
 :focus:not(:focus-visible) {
     outline: none;
 }
-  
+
 :target {
-    scroll-margin-top: 2ex;
+    scroll-margin-top: calc(var(--header-height) + var(--space-m));
 }
 
-a {
-    color: var(--link);
-}
-  
-a:hover {
-    color: var(--link-hover);
-    text-decoration: none;
-}
-
-hr {
-    border-top: 1px solid var(--divider);
-    border-bottom: none;
-}
-
-p > code,
-li > code {
-    background-color: var(--background-soft);
-    padding: 0.2ch 0.5ch;
-    border-radius: var(--border-radius);
-}
-
-table {
-    width: 100%;
-    border: 1px solid var(--foreground-soft);
-    border-collapse: collapse;
-}
-
-table th {
-    font-family: var(--font-headings);
-}
-
-table th,
-table td {
-    border: 1px solid var(--foreground-soft);
-    padding: var(--space-2xs);
-}
+/* ---- typography --------------------------------------------------------- */
 
 h1,
 h2,
@@ -86,133 +66,181 @@ h3,
 h4,
 h5,
 h6 {
-    font-family: var(--font-headings);
-}
-
-h1,
-h2,
-h3 {
-    line-height: 1;
-    letter-spacing: var(--tracking-s);
+    font-family: var(--font-display);
+    color: var(--ink-strong);
+    font-weight: var(--weight-black);
+    line-height: var(--leading-heading);
+    letter-spacing: var(--tracking-display);
+    text-wrap: balance;
 }
 
 h1 {
-    font-size: var(--step-4);
+    font-size: var(--step-6);
+    line-height: var(--leading-display);
 }
 
 h2 {
-    font-size: var(--step-3);
+    font-size: var(--step-4);
 }
 
 h3 {
     font-size: var(--step-2);
+    letter-spacing: var(--tracking-tight);
 }
 
 h4 {
     font-size: var(--step-1);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-tight);
 }
 
-h5,
-h6 {
+h5 {
     font-size: var(--step-0);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-tight);
 }
 
-blockquote:not([class]) {
-    font-family: var(--font-serif);
-    font-size: var(--step-1);
-}
-  
-blockquote:not([class]) p:last-of-type {
-    font-family: var(--font-base);
-    font-size: var(--size-step-1);
-    font-weight: normal;
+h6 {
+    font-size: var(--step--1);
+    font-weight: var(--weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+    color: var(--ink-muted);
 }
 
-h4,
-h5,
-h6,
-p,
-li,
-blockquote:not([class]) {
-  max-width: 65ch;
+p {
+    text-wrap: pretty;
 }
 
-p:has(> picture) {
-    max-width: initial;
-    width: 100%;
+a {
+    color: var(--link);
+    text-decoration-color: var(--link-underline);
+    text-underline-offset: 0.18em;
+    text-decoration-thickness: 1px;
+    transition: color var(--transition-fade), text-decoration-color var(--transition-fade);
 }
 
-h1,
-h3 {
-  max-width: 20ch;
+a:hover {
+    color: var(--link-hover);
+    text-decoration-color: currentColor;
 }
 
-h2 {
-    max-width: none;
+strong,
+b {
+    font-weight: var(--weight-bold);
+    color: var(--ink-strong);
+}
+
+small {
+    font-size: var(--step--1);
+}
+
+hr {
+    height: 1px;
+    border: 0;
+    background-color: var(--divider);
+    margin-block: var(--space-l);
 }
 
 mark {
-    background-color: var(--nord13);
-    color: var(--nord0);
+    background-color: color-mix(in srgb, var(--brand-terracotta) 30%, transparent);
+    color: var(--ink-strong);
+    padding: 0.05em 0.25em;
+    border-radius: var(--radius-xs);
 }
+
+abbr[title] {
+    text-decoration-style: dotted;
+    cursor: help;
+}
+
+/* ---- code --------------------------------------------------------------- */
+
+code,
+kbd,
+samp,
+pre {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+}
+
+:not(pre) > code {
+    background-color: var(--code-inline-background);
+    color: var(--ink-strong);
+    padding: 0.15em 0.4em;
+    border-radius: var(--radius-xs);
+}
+
+kbd {
+    background-color: var(--surface-raised);
+    border: 1px solid var(--border-strong);
+    border-bottom-width: 2px;
+    border-radius: var(--radius-xs);
+    padding: 0.1em 0.4em;
+}
+
+/* ---- tables ------------------------------------------------------------- */
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--step--1);
+    text-align: left;
+}
+
+table caption {
+    caption-side: bottom;
+    color: var(--ink-muted);
+    font-size: var(--step--1);
+    padding-top: var(--space-xs);
+    text-align: left;
+}
+
+table th {
+    font-family: var(--font-display);
+    font-weight: var(--weight-bold);
+    color: var(--ink-strong);
+    letter-spacing: var(--tracking-tight);
+}
+
+table thead th {
+    border-bottom: 2px solid var(--border-strong);
+}
+
+table th,
+table td {
+    padding: var(--space-xs) var(--space-s);
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+}
+
+table tbody tr:last-child td {
+    border-bottom: 0;
+}
+
+/* ---- media -------------------------------------------------------------- */
 
 figure {
     position: relative;
+    margin: 0;
+}
+
+figure img {
+    border-radius: var(--radius-m);
 }
 
 figure > figcaption {
-    position: absolute;
-    bottom: var(--space-s-m);
-    left: var(--space-s-m);
-    color: var(--background);
-    margin-right: var(--space-s-m);
-    background-color: var(--foreground);
-    padding: var(--space-3xs) var(--space-xs);
-    box-shadow: 0px 4px color-mix(in srgb, var(--foreground), var(--black) 9%);
-    border-radius: var(--border-radius);
+    color: var(--ink-muted);
     font-size: var(--step--1);
-}
-
-figure > figcaption::selection {
-    background: var(--nord13);
-    color: var(--nord0);
-}
-
-.entry-header {
-    margin-bottom: var(--space-m, 1em);
-}
-
-.entry-content > * + * {
-    margin-top: var(--space-m, 1em);
-}
-
-/* utilities */
-
-.screen-reader-text {
-    border: 0;
-    clip: rect(1px,1px,1px,1px);
-    clip-path: inset(50%);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
-    word-wrap: normal !important;
-}
-
-.rounded {
-    border-radius: var(--border-radius);
-}
-
-.subtle {
-    font-size: var(--step--1);
-    color: var(--foreground-soft);
+    line-height: var(--leading-tight);
+    padding-top: var(--space-2xs);
+    max-width: var(--measure);
 }
 
 .oembed-youtube,
 .oembed-vimeo {
-    border: 1px solid var(--foreground);
+    border-radius: var(--radius-m);
+    overflow: hidden;
 }
 
 .oembed-youtube lite-youtube {
@@ -224,510 +252,481 @@ figure > figcaption::selection {
     position: relative;
 }
 
-/* notice */
-
-.notice {
-    padding: var(--space-s) var(--space-s) calc(var(--space-s) - 4px) var(--space-s);
-    border-radius: var(--border-radius);
-    color: var(--white);
-    background-color: var(--nord9);
-    box-shadow: 0px 4px color-mix(in srgb, var(--nord9), var(--black) 9%);
-    width: 100%;
-    max-width: initial;
-}
-
-.notice.notice-warning {
-    background-color: var(--nord13);
-    box-shadow: 0px 4px color-mix(in srgb, var(--nord13), var(--black) 9%);
-}
-
-.notice.notice-error {
-    background-color: var(--nord11);
-    box-shadow: 0px 4px color-mix(in srgb, var(--nord11), var(--black) 9%);
-}
-
-.notice a {
-    color: var(--nord5);
-}
-
-.notice a:hover {
-    color: var(--white);
-}
-
-.notice p {
-    max-width: initial;
-    display: flex;
-    align-items: center;
-    gap: var(--space-s);
-}
-
-.notice-icon {
-    width: 1.25em;
-    height: 1.25em;
-    fill: currentColor;
-    flex-shrink: 0;
-}
-
-/* body and containers */
-
-body {
-    display: flex;
-    flex-direction: column;
-}
-
-#content {
-    padding: 0px var(--space-m-3xl) var(--space-m) var(--space-m-3xl);
-    flex-grow: 1;
-}
-
-/* skip to content */
-
-.skip-link {
-	transform: translateY( -140px );
-	transition: var(--transition-base);
-    padding: var(--space-s-l);
-    background-color: var(--foreground);
-    color: var(--background);
-    font-family: var(--font-headings);
-    font-weight: 500;
-    border-radius: 0;
-    width: 100%;
-}
-
-.skip-link:hover {
-    color: var(--background);
-}
-
-.skip-link:focus {
-	transform: translateY( 0 );
-	position: fixed;
-	display: block;
-	clip: auto !important;
-	clip-path: none;
-	height: auto;
-    width: 100%;
-    z-index: 10;
-}
-
-/* header and navigation */
-
-.navigation {
-    padding: var(--space-s-l);
-    display: flex;
-    gap: var(--space-s-l);
-    align-items: center;
-    font-family: var(--font-headings);
-    flex-direction: column;
-    font-weight: 400;
-    font-size: x-large;
-}
-
-@media (min-width: 600px) {
-    .navigation {
-        flex-direction: row;
-    }
-}
-
-.site-logo {
-    max-width: 130px;
-    height: auto;
-}
-
-@media (min-width: 600px) {
-    .site-logo {
-        max-width: 100px;
-        width: 33%;
-        position: relative;
-        top: -8px;
-    }
-}
-
-.site-logo svg {
-    color: var(--foreground);
-}
-
-.site-logo svg .cls-1 {
-    fill: var(--foreground);
-}
-
-.site-logo svg .cls-2 {
-    fill: none;
-    stroke: var(--foreground);
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    stroke-width: .6px;
-}
-
-.site-logo:focus {
-    outline: none;
-}
-
-.site-logo:focus svg {
-    color: var(--link);
-}
-
-.navigation-menu {
-    list-style: none;
-    border: 0;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    gap: var(--space-s-m);
-    flex-grow: 1;
-}
-
-.navigation-menu li {
-    margin: 0;
-    padding: 0;
-}
-
-.navigation-menu li a {
-    text-decoration: none;
-    letter-spacing: var(--tracking-s);
-}
-
-.navigation-menu li a:focus {
-    outline-offset: 0.6ch;
-}
-
-a[aria-current="page"] {
-    color: var(--link-hover);
-    text-decoration: none;
-}
-
-.social-icon {
-    color: var(--link);
-}
-  
-.social-icon:hover {
-    color: var(--link-hover);
-    text-decoration: none;
-}
-
-/* home */
-
-.home #content {
-    display: flex;
-    flex-direction: column;
-}
-
-.home .site-intro {
-    text-align: center;
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-}
-
-.home .site-intro svg {
-    max-width: 50%;
-}
-
-.home .site-intro p {
-    margin: 0 0 0 0;
-    max-width: 550px;
-}
-
-.image-container {
-    display: flex;
-    align-items: center;
-    background: url('assets/img/en.jpg') no-repeat center center; 
-    background-size: cover; 
-    width: 100%; 
-    height: 100%; 
-    margin: 0;
-}
-
-#image-buffer {
-    flex: 1;
-}
-
-/* posts */
-
-.postlist {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-.postlist li {
-    margin-bottom: var(--space-s-m);
-
-    &:last-child {
-        margin-bottom: 0;
-    }
-}
-
-.postlist .postlist-date {
-    color: var(--foreground-soft);
-    font-size: var(--step--1);
-    display: block;
-}
-
-.posts .meta {
-    list-style: none;
-    margin: 0 0 var(--space-s-2xl) 0;
-    padding: 0;
-}
-
-@media (min-width: 600px) {
-    .posts .meta {
-        display: flex;
-        gap: var(--space-3xs);
-    }
-
-    .posts .meta-reading-time::before {
-        content: '•';
-        display: inline-block;
-        padding-left: var(--space-2xs);
-        padding-right: var(--space-2xs);
-    }    
-}
-
-.posts .meta-date,
-.posts .meta-reading-time {
-    color: var(--foreground-soft);
-}
-
-/* posts affiliate disclaimer */
-
-.affiliate {
-    border: 1px solid var(--background);
-    border-radius: var(--border-radius);
-    padding: 10px;
-    margin-bottom: 20px;
-    max-width: 65ch;
-    text-align: center;
-    background-color: var(--foreground);
-    font-size: var(--step-0);
-    color: var(--background);
-}
-
-/* footer */
-
-.footer {
-    padding: var(--space-s-l);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.copyright{
-    font-size: var(--step--1);
-}
-
-.rss-icon {
-    width: 44px;
-}
-
-/* feed xslt */
-
-.rss-xslt h1 {
-    margin-top: var(--space-s-l);
-}
-
-.rss-xslt .posts {
-    list-style: none;
-    margin: var(--space-s-l) 0 0 0;
-    padding: 0;
-}
-
-.rss-xslt .posts li {
-    margin-bottom: var(--space-s-m);
-
-    &:last-child {
-        margin-bottom: 0;
-    }
-}
-
-.rss-xslt .posts span {
-    color: var(--foreground-soft);
-    font-size: var(--step--1);
-    display: block;
-}
-
-
-/* SVG Map */
-svg .svg-map {
-    fill: var(--link);
-}
-
-svg .svg-map-disabled {
-    fill: var(--nord3);
-}
-
-svg .svg-map:hover {
-    fill: var(--link-hover);
-}
-
-svg .svg-map-disabled:hover {
-    fill: var(--nord3);
-    cursor: not-allowed;
-    text-decoration: none;
-}
-
-@media (max-width: 768px) {
-    .scale-svg-map {
-        transform: scale(1.3);
-        padding: 0 0 0 0; 
-        margin: 0 0 0 0;   
-    }
-}
-
-/* Home Hero */
-.home-hero {
-    display: flex;
-    align-items: center;
-    background: url('https://images.unsplash.com/photo-1728763576800-8f197d048758') no-repeat center center; 
-    background-size: cover; 
-    border-radius: var(--border-radius);
-    width: 100%; 
-    height: 100%;
-    margin: 0px;
-}
-
-.home-hero-spacer {
-    flex: 1;
-}
-
-.home-hero-content {
-    flex: 1;
-    border-radius: 0 var(--border-radius) var(--border-radius) 0;
-    padding: var(--space-3xl) var(--space-l) var(--space-3xl) var(--space-l); 
-    max-width: 40%;
-    color: white;
-    text-align: left;
-    font-family: var(--font-headings);
-    letter-spacing: 0.5px;
-    background: rgba(0, 0, 0, 0.4);
-}
-
-@media (max-width: 768px) {
-    .home-hero {
-        background: none;
-    }
-
-    .home-hero-spacer {
-        display: none;
-    }
-
-    .home-hero-content {
-        background: none;
-        padding: 0 0 0 0;
-        max-width: 100%;
-        text-align: center;
-    }
-}
-
-/* Home Columns */
-.travel-guides-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-s);
-    padding-top: var(--space-s);
-}
-
-.travel-guide {
-    flex: 1;
-    min-width: 300px;
-    max-width: 33%;
-    box-sizing: border-box;
-    display: flex;
-    flex-direction: column;
-}
-
-.travel-guide > div:first-child {
-    flex: 1;
-}
-
-.travel-guide figure {
-    aspect-ratio: 3 / 2;
-    overflow: hidden;
-    margin: 0;
-    width: 100%;
-}
-
-.travel-guide figure picture {
-    display: block;
-    width: 100%;
-    height: 100%;
-}
-
-.travel-guide figure img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
-}
-
-@media (max-width: 768px) {
-    .travel-guide {
-        flex: 100%;
-        max-width: 100%;
-    }
-}
-
-.center-text {
-    text-align: center!important;
-}
-
-/* Countries Columns */
-.travel-guides-container-countries {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-s);
-    padding-top: var(--space-s);
-    max-width: 70%; 
-    margin-top: var(--space-3xs); 
-    padding: var(--space-3xs);
-}
-
-.travel-guide-countries {
-    flex: 1;
-    min-width: 300px;
-    max-width: 33%;
-    box-sizing: border-box;
-}
-
-/* Image Stock Photo Link */
+/* photo credit chip that the image shortcode injects */
 .bottom-left-text {
     position: absolute;
-    bottom: var(--space-s-m);
-    right: var(--space-s-m);
-    color: var(--background);
-    margin-right: var(--space-s-m);
-    background-color: var(--foreground);
-    padding: var(--space-3xs) var(--space-xs);
-    box-shadow: 0px 4px color-mix(in srgb, var(--foreground), var(--black) 9%);
-    border-radius: var(--border-radius);
-    font-size: var(--step--1);
+    bottom: var(--space-s);
+    right: var(--space-s);
+    white-space: nowrap;
+    max-width: calc(100% - var(--space-l));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--white);
+    background-color: color-mix(in srgb, var(--brand-indigo-ink) 80%, transparent);
+    backdrop-filter: blur(6px);
+    padding: var(--space-3xs) var(--space-2xs);
+    border-radius: var(--radius-pill);
+    font-size: var(--step--2);
+    line-height: 1.4;
 }
 
-@media (max-width: 1024px) { /* hide on mobile */
+.bottom-left-text a {
+    color: var(--white);
+}
+
+@media (max-width: 48rem) {
     .bottom-left-text {
         display: none;
     }
 }
 
-/* Scroll to Top */
+/* =========================================================================
+   Layout shells
+   ========================================================================= */
+
+#content {
+    flex-grow: 1;
+    padding-bottom: var(--space-2xl);
+}
+
+/* Centred, gutter-aware container. Modifiers change the max width only. */
+.shell {
+    width: 100%;
+    max-width: var(--width-page);
+    margin-inline: auto;
+    padding-inline: var(--gutter);
+}
+
+.shell--wide {
+    max-width: var(--width-wide);
+}
+
+.shell--content {
+    max-width: calc(var(--width-content) + var(--gutter) * 2);
+}
+
+.shell--flush {
+    padding-inline: 0;
+}
+
+/* Vertical rhythm between page sections */
+.section {
+    padding-block: var(--space-xl-2xl);
+}
+
+.section--tight {
+    padding-block: var(--space-l-xl);
+}
+
+.section--tinted {
+    background-color: var(--surface-alt);
+}
+
+.section--sunken {
+    background-color: var(--surface-sunken);
+}
+
+.section + .section--tinted,
+.section--tinted + .section--tinted {
+    margin-top: 0;
+}
+
+/* Section header: eyebrow / title / lede / optional action */
+.section-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    margin-bottom: var(--space-l);
+    max-width: var(--measure);
+}
+
+.section-header--center {
+    align-items: center;
+    text-align: center;
+    margin-inline: auto;
+}
+
+.section-header > p:not(.eyebrow) {
+    color: var(--ink-muted);
+    font-size: var(--step-1);
+    line-height: var(--leading-tight);
+    margin: 0;
+}
+
+.section-header__title {
+    margin: 0;
+}
+
+.section-header__actions {
+    margin-top: var(--space-xs);
+}
+
+/* Grid used by every card collection on the site */
+.grid {
+    display: grid;
+    gap: var(--space-m);
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 17.5rem), 1fr));
+}
+
+.grid--2 {
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 22rem), 1fr));
+}
+
+.grid--4 {
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 13.5rem), 1fr));
+}
+
+.grid--gapless {
+    gap: var(--space-xs);
+}
+
+.stack > * + * {
+    margin-top: var(--space-m);
+}
+
+.cluster {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-xs);
+}
+
+/* =========================================================================
+   Small shared pieces
+   ========================================================================= */
+
+/* Eyebrow: the small uppercase kicker above a heading */
+.eyebrow {
+    display: inline-block;
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-label);
+    text-transform: uppercase;
+    color: var(--accent-deep);
+    margin: 0;
+}
+
+.eyebrow--muted {
+    color: var(--ink-faint);
+}
+
+.eyebrow--invert {
+    color: var(--brand-blush);
+}
+
+/* Script flourish, straight from the logo lettering */
+.script {
+    font-family: var(--font-script);
+    font-weight: var(--weight-regular);
+    letter-spacing: var(--tracking-normal);
+    line-height: 1.3;
+}
+
+.lede {
+    font-size: var(--step-1);
+    line-height: var(--leading-tight);
+    color: var(--ink-muted);
+    max-width: var(--measure);
+}
+
+.meta-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2xs);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    color: var(--ink-muted);
+    font-size: var(--step--1);
+}
+
+.meta-line > li + li::before {
+    content: '·';
+    display: inline-block;
+    padding-right: var(--space-2xs);
+    color: var(--ink-faint);
+}
+
+/* Tag / category pill */
+.tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    font-family: var(--font-display);
+    font-size: var(--step--2);
+    font-weight: var(--weight-semibold);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    background-color: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    padding: 0.35em 0.85em;
+    text-decoration: none;
+    transition: background-color var(--transition-fade), color var(--transition-fade), border-color var(--transition-fade);
+}
+
+a.tag:hover {
+    background-color: var(--accent-wash);
+    border-color: var(--accent-soft);
+    color: var(--accent-deep);
+}
+
+.tag--accent {
+    background-color: var(--accent-wash);
+    border-color: transparent;
+    color: var(--accent-deep);
+}
+
+.tag--solid {
+    background-color: var(--surface-invert);
+    border-color: transparent;
+    color: var(--ink-invert);
+}
+
+/* Divider with a small centred ornament */
+.rule-ornament {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
+    color: var(--border-strong);
+}
+
+.rule-ornament::before,
+.rule-ornament::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background-color: var(--divider);
+}
+
+.rule-ornament span {
+    font-family: var(--font-script);
+    color: var(--ink-faint);
+    font-size: var(--step-0);
+}
+
+/* =========================================================================
+   Utilities
+   ========================================================================= */
+
+.screen-reader-text {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    word-wrap: normal !important;
+}
+
+.rounded {
+    border-radius: var(--radius-m);
+}
+
+.subtle {
+    font-size: var(--step--1);
+    color: var(--ink-muted);
+}
+
+.center-text {
+    text-align: center;
+}
+
+.text-muted {
+    color: var(--ink-muted);
+}
+
+.full-bleed {
+    width: 100vw;
+    margin-inline: calc(50% - 50vw);
+}
+
+/* Skip link */
+.skip-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 100;
+    transform: translateY(-140%);
+    transition: transform var(--transition-base);
+    padding: var(--space-s) var(--space-m);
+    background-color: var(--surface-invert);
+    color: var(--ink-invert);
+    font-family: var(--font-display);
+    font-weight: var(--weight-bold);
+    text-decoration: none;
+    border-radius: 0 0 var(--radius-m) 0;
+}
+
+.skip-link:focus {
+    transform: translateY(0);
+    position: fixed;
+    clip: auto !important;
+    clip-path: none;
+    height: auto;
+    width: auto;
+    color: var(--ink-invert);
+}
+
+/* Back to top */
 .return-to-top {
     position: fixed;
-    bottom: 20px;
-    right: 20px;
-    padding: 0.5rem 0.75rem;
-    background-color: var(--foreground);
-    color: white;
+    bottom: var(--space-m);
+    right: var(--space-m);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    padding: 0;
+    background-color: var(--surface-invert);
+    color: var(--ink-invert);
     border: none;
-    border-radius: var(--border-radius);
+    border-radius: var(--radius-circle);
+    font-family: var(--font-display);
+    font-size: var(--step--1);
+    font-weight: var(--weight-bold);
     cursor: pointer;
-    display: none; /* Hidden by default */
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    z-index: 1000;
-    transition: opacity 0.3s ease;
+    box-shadow: var(--shadow-m);
+    z-index: 40;
+    transition: transform var(--transition-base), background-color var(--transition-base);
 }
 
 .return-to-top:hover {
-    background-color: var(--background);
-    color: var(--foreground);
+    background-color: var(--accent-deep);
+    color: var(--white);
+    transform: translateY(-2px);
+}
+
+/* =========================================================================
+   Notices (generated by the markdown notices transform)
+   ========================================================================= */
+
+.notice {
+    display: block;
+    width: 100%;
+    max-width: var(--measure);
+    padding: var(--space-s) var(--space-m);
+    border-radius: var(--radius-m);
+    border: 1px solid color-mix(in srgb, var(--signal-info) 30%, transparent);
+    border-left: 4px solid var(--signal-info);
+    background-color: color-mix(in srgb, var(--signal-info) 8%, var(--surface));
+    color: var(--ink);
+    margin-inline: 0;
+    font-style: normal;
+}
+
+.notice p {
+    max-width: none;
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-xs);
+    margin: 0;
+    font-size: var(--step-0);
+}
+
+.notice a {
+    color: var(--link);
+}
+
+.notice-icon {
+    width: 1.35em;
+    height: 1.35em;
+    flex-shrink: 0;
+    fill: var(--signal-info);
+    margin-top: 0.2em;
+}
+
+.notice.notice-warning {
+    border-color: color-mix(in srgb, var(--signal-warning) 35%, transparent);
+    border-left-color: var(--signal-warning);
+    background-color: color-mix(in srgb, var(--signal-warning) 10%, var(--surface));
+}
+
+.notice.notice-warning .notice-icon {
+    fill: var(--signal-warning);
+}
+
+.notice.notice-error {
+    border-color: color-mix(in srgb, var(--signal-danger) 35%, transparent);
+    border-left-color: var(--signal-danger);
+    background-color: color-mix(in srgb, var(--signal-danger) 9%, var(--surface));
+}
+
+.notice.notice-error .notice-icon {
+    fill: var(--signal-danger);
+}
+
+/* =========================================================================
+   Interactive world map (countries page)
+   ========================================================================= */
+
+.map-panel {
+    background-color: var(--surface-alt);
+    border-radius: var(--radius-l);
+    padding: var(--space-m-l);
+    overflow: hidden;
+}
+
+.scale-svg-map {
+    width: 100%;
+    height: auto;
+}
+
+svg .svg-map {
+    fill: var(--brand-indigo);
+    transition: fill var(--transition-fade);
+}
+
+svg .svg-map-disabled {
+    fill: var(--border-strong);
+}
+
+svg .svg-map:hover {
+    fill: var(--accent);
+}
+
+svg .svg-map-disabled:hover {
+    fill: var(--border-strong);
+    cursor: not-allowed;
+    text-decoration: none;
+}
+
+@media (max-width: 48rem) {
+    .scale-svg-map {
+        transform: scale(1.25);
+    }
+}
+
+/* =========================================================================
+   RSS / feed XSLT page
+   ========================================================================= */
+
+.rss-xslt {
+    max-width: var(--width-content);
+    margin-inline: auto;
+    padding: var(--space-xl) var(--gutter);
+}
+
+.rss-xslt .posts {
+    list-style: none;
+    margin: var(--space-l) 0 0 0;
+    padding: 0;
+}
+
+.rss-xslt .posts li {
+    padding-block: var(--space-s);
+    border-bottom: 1px solid var(--divider);
+}
+
+.rss-xslt .posts span {
+    color: var(--ink-muted);
+    font-size: var(--step--1);
+    display: block;
 }

--- a/src/assets/css/variables.css
+++ b/src/assets/css/variables.css
@@ -1,124 +1,271 @@
+/* =========================================================================
+   Design tokens
+   Everything visual in this site resolves back to a token defined here.
+   Documented and previewed at /styleguide/
+   ========================================================================= */
+
+/* ---- fonts ------------------------------------------------------------ */
+
 @font-face {
     font-family: 'Albert Sans';
-    src: url('../fonts/Albert_Sans/AlbertSans-VariableFont_wght.ttf') format('ttf');
+    src: url('../fonts/Albert_Sans/AlbertSans-VariableFont_wght.ttf') format('truetype');
     font-weight: 100 900;
     font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'Albert Sans';
+    src: url('../fonts/Albert_Sans/AlbertSans-Italic-VariableFont_wght.ttf') format('truetype');
+    font-weight: 100 900;
+    font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: 'Bad Script';
-    src: url('../fonts/Bad_Script/BadScript-Regular.ttf') format('ttf');
-    font-weight: 100 900;
+    src: url('../fonts/Bad_Script/BadScript-Regular.ttf') format('truetype');
+    font-weight: 400;
     font-style: normal;
+    font-display: swap;
 }
 
 :root {
-    /* branding */
+
+    /* ---- brand palette ------------------------------------------------
+       The five colours pulled from the Daniela and Will logo and artwork.
+       Never reference these directly in components — use the semantic
+       tokens below so dark mode keeps working. */
+
+    --brand-indigo: #5761a2;
+    --brand-indigo-deep: #3c4478;
+    --brand-indigo-ink: #232741;
+    --brand-terracotta: #e99253;
+    --brand-terracotta-deep: #c9702f;
+    --brand-blush: #e1b09d;
+    --brand-cream: #fbede3;
+    --brand-mist: #d3dae8;
+    --brand-sand: #f6f1ea;
+
+    --white: #fff;
     --black: #000;
-	--white: #fff;
-    --nord0: #5761a2;
-    --nord1: #3b4252;
-    --nord2: #e99253;
-    --nord3: #4c566a;
-    --nord4: #e99253;
-    --nord5: #d3dae8;
-    --nord6: #e1b09d;
-    --nord7: #020202;
-    --nord8: #fbede3;
-    --nord9: #81a1c1;
-    --nord10: #5e81ac;
-    --nord11: #bf616a;
-    --nord12: #d08770;
-    --nord13: #efc571;
-    --nord14: #a3be8c;
-    --nord15: #b48ead;
+    --grey-050: #faf9f7;
+    --grey-100: #f1efec;
+    --grey-200: #e4e1dc;
+    --grey-300: #cbc7c0;
+    --grey-400: #a09b93;
+    --grey-500: #6f6a63;
+    --grey-700: #3b3a38;
+    --grey-900: #1d1c1f;
 
-    /* colours */
-    --background: var(--nord6);
-    --background-soft: var(--nord4);
-    --foreground: var(--nord0);
-    --foreground-soft: color-mix(in srgb, var(--nord6) 30%, var(--nord0));
-    --link: color-mix(in srgb, var(--nord10) 70%, var(--nord0));
-    --link-hover: var(--nord5);
-    --divider: color-mix(in srgb, var(--nord6) 80%, var(--nord0));
+    /* status colours */
+    --signal-info: var(--brand-indigo);
+    --signal-success: #4f8a68;
+    --signal-warning: #d99b2b;
+    --signal-danger: #c25a52;
 
-    /* syntax highlighting */
-    --code-background: var(--nord0);
-    --code-default: var(--nord6);
-    --code-regex: var(--nord13);
-    --code-tag: var(--nord9);
-    --code-comment: var(--nord3);
-    --code-selector: var(--nord14);
-    --code-number: var(--nord15);
-    --code-function: var(--nord8);
+    /* ---- semantic surfaces + ink -------------------------------------- */
 
-    /* typography */
-    --font-base: "Albert Sans", Verdana, Arial, Times, 'Times New Roman', serif;
-    --font-headings: "Segoe Script", "Bad Script", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    --font-quote: Verdana, Arial, Times, 'Times New Roman', serif;
-    --font-mono: "Fira Code", Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-    /* @link https://utopia.fyi/type/calculator?c=320,18,1.2,1500,22,1.333,6,1,800&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l&g=s,l,xl,12 */
-    --step--1: clamp(0.94rem, calc(0.91rem + 0.13vw), 1.03rem);
-    --step-0: clamp(1.13rem, calc(1.06rem + 0.34vw), 1.38rem);
-    --step-1: clamp(1.35rem, calc(1.22rem + 0.66vw), 1.83rem);
-    --step-2: clamp(1.62rem, calc(1.40rem + 1.12vw), 2.44rem);
-    --step-3: clamp(1.94rem, calc(1.59rem + 1.78vw), 3.26rem);
-    --step-4: clamp(2.33rem, calc(1.79rem + 2.72vw), 4.34rem);
-    --step-5: clamp(2.80rem, calc(1.99rem + 4.05vw), 5.79rem);
-    --step-6: clamp(3.36rem, calc(2.18rem + 5.91vw), 7.71rem);
+    --surface: var(--white);
+    --surface-alt: var(--brand-cream);
+    --surface-sunken: var(--grey-050);
+    --surface-raised: var(--white);
+    --surface-invert: var(--brand-indigo-ink);
+    --surface-accent: var(--brand-indigo);
 
-    /* spacing / layout */
-    --tracking: -0.02ch;
-    --tracking-s: -0.055ch;
-    --gutter: var(--space-s-m);
-    --border-radius: var(--step-0);
-    /* @link https://utopia.fyi/space/calculator?c=320,18,1.2,1500,22,1.333,6,1,800&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l|m-3xl|s-2xl&g=s,l,xl,12 */
-    --space-3xs: clamp(0.31rem, calc(0.30rem + 0.08vw), 0.38rem);
-    --space-2xs: clamp(0.56rem, calc(0.53rem + 0.17vw), 0.69rem);
-    --space-xs: clamp(0.88rem, calc(0.82rem + 0.25vw), 1.06rem);
-    --space-s: clamp(1.13rem, calc(1.06rem + 0.34vw), 1.38rem);
-    --space-m: clamp(1.69rem, calc(1.59rem + 0.51vw), 2.06rem);
-    --space-l: clamp(2.25rem, calc(2.11rem + 0.68vw), 2.75rem);
-    --space-xl: clamp(3.38rem, calc(3.17rem + 1.02vw), 4.13rem);
-    --space-2xl: clamp(4.50rem, calc(4.23rem + 1.36vw), 5.50rem);
-    --space-3xl: clamp(6.75rem, calc(6.34rem + 2.03vw), 8.25rem);
+    --ink: #22232e;
+    --ink-strong: #14151d;
+    --ink-muted: #61637a;
+    --ink-faint: #8b8d9f;
+    --ink-invert: var(--white);
+    --ink-on-accent: var(--white);
+
+    --border: #e6e3de;
+    --border-strong: #cfcbc4;
+    --divider: var(--border);
+
+    --accent: var(--brand-terracotta);
+    --accent-deep: var(--brand-terracotta-deep);
+    --accent-soft: var(--brand-blush);
+    --accent-wash: var(--brand-cream);
+
+    --link: var(--brand-indigo);
+    --link-hover: var(--brand-terracotta-deep);
+    --link-underline: color-mix(in srgb, var(--brand-indigo) 35%, transparent);
+
+    --scrim: color-mix(in srgb, var(--brand-indigo-ink) 55%, transparent);
+    --scrim-strong: color-mix(in srgb, var(--brand-indigo-ink) 72%, transparent);
+
+    /* footer keeps its own pair so it stays dark in both themes */
+    --footer-surface: var(--brand-indigo-ink);
+    --footer-ink: var(--white);
+    --footer-heading: var(--brand-blush);
+
+    /* ---- syntax highlighting ------------------------------------------ */
+
+    --code-background: var(--brand-indigo-ink);
+    --code-inline-background: var(--grey-100);
+    --code-default: var(--brand-cream);
+    --code-regex: #efc571;
+    --code-tag: #9fb3dd;
+    --code-comment: #8b8d9f;
+    --code-selector: #a3be8c;
+    --code-number: #d9a6cc;
+    --code-function: var(--brand-blush);
+
+    /* ---- typography ---------------------------------------------------- */
+
+    --font-body: 'Albert Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    --font-display: 'Albert Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    --font-script: 'Bad Script', 'Segoe Script', 'Brush Script MT', cursive;
+    --font-mono: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+
+    /* fluid type scale — 320px → 1500px viewport
+       @link https://utopia.fyi/type/calculator */
+    --step--2: clamp(0.72rem, calc(0.71rem + 0.06vw), 0.76rem);
+    --step--1: clamp(0.84rem, calc(0.82rem + 0.10vw), 0.91rem);
+    --step-0: clamp(1.00rem, calc(0.96rem + 0.17vw), 1.13rem);
+    --step-1: clamp(1.19rem, calc(1.13rem + 0.28vw), 1.41rem);
+    --step-2: clamp(1.41rem, calc(1.31rem + 0.44vw), 1.76rem);
+    --step-3: clamp(1.68rem, calc(1.52rem + 0.68vw), 2.20rem);
+    --step-4: clamp(2.00rem, calc(1.76rem + 1.02vw), 2.75rem);
+    --step-5: clamp(2.38rem, calc(2.03rem + 1.49vw), 3.43rem);
+    --step-6: clamp(2.83rem, calc(2.33rem + 2.13vw), 4.29rem);
+    --step-7: clamp(3.36rem, calc(2.67rem + 2.99vw), 5.36rem);
+
+    /* weights */
+    --weight-regular: 400;
+    --weight-medium: 500;
+    --weight-semibold: 600;
+    --weight-bold: 700;
+    --weight-black: 800;
+
+    /* tracking */
+    --tracking-display: -0.035em;
+    --tracking-tight: -0.015em;
+    --tracking-normal: 0em;
+    --tracking-wide: 0.06em;
+    --tracking-label: 0.16em;
+
+    /* leading */
+    --leading-display: 1.04;
+    --leading-heading: 1.16;
+    --leading-body: 1.7;
+    --leading-tight: 1.35;
+
+    /* measure */
+    --measure: 68ch;
+    --measure-narrow: 48ch;
+
+    /* ---- spacing ------------------------------------------------------- */
+
+    --space-3xs: clamp(0.25rem, calc(0.24rem + 0.06vw), 0.31rem);
+    --space-2xs: clamp(0.50rem, calc(0.48rem + 0.09vw), 0.56rem);
+    --space-xs: clamp(0.75rem, calc(0.72rem + 0.13vw), 0.84rem);
+    --space-s: clamp(1.00rem, calc(0.96rem + 0.17vw), 1.13rem);
+    --space-m: clamp(1.50rem, calc(1.44rem + 0.26vw), 1.69rem);
+    --space-l: clamp(2.00rem, calc(1.92rem + 0.34vw), 2.25rem);
+    --space-xl: clamp(3.00rem, calc(2.88rem + 0.51vw), 3.38rem);
+    --space-2xl: clamp(4.00rem, calc(3.83rem + 0.68vw), 4.50rem);
+    --space-3xl: clamp(6.00rem, calc(5.75rem + 1.02vw), 6.75rem);
+
     /* one-up pairs */
-    --space-3xs-2xs: clamp(0.31rem, calc(0.21rem + 0.51vw), 0.69rem);
-    --space-2xs-xs: clamp(0.56rem, calc(0.43rem + 0.68vw), 1.06rem);
-    --space-xs-s: clamp(0.88rem, calc(0.74rem + 0.68vw), 1.38rem);
-    --space-s-m: clamp(1.13rem, calc(0.87rem + 1.27vw), 2.06rem);
-    --space-m-l: clamp(1.69rem, calc(1.40rem + 1.44vw), 2.75rem);
-    --space-l-xl: clamp(2.25rem, calc(1.74rem + 2.54vw), 4.13rem);
-    --space-xl-2xl: clamp(3.38rem, calc(2.80rem + 2.88vw), 5.50rem);
-    --space-2xl-3xl: clamp(4.50rem, calc(3.48rem + 5.08vw), 8.25rem);
-    /* custom pairs */
-    --space-s-l: clamp(1.13rem, calc(0.68rem + 2.20vw), 2.75rem);
-    --space-m-3xl: clamp(1.69rem, calc(-0.09rem + 8.90vw), 8.25rem);
-    --space-s-2xl: clamp(1.13rem, calc(-0.06rem + 5.93vw), 5.50rem);
+    --space-3xs-2xs: clamp(0.25rem, calc(0.18rem + 0.34vw), 0.50rem);
+    --space-2xs-xs: clamp(0.50rem, calc(0.41rem + 0.42vw), 0.81rem);
+    --space-xs-s: clamp(0.75rem, calc(0.64rem + 0.51vw), 1.13rem);
+    --space-s-m: clamp(1.00rem, calc(0.81rem + 0.93vw), 1.69rem);
+    --space-m-l: clamp(1.50rem, calc(1.29rem + 1.02vw), 2.25rem);
+    --space-l-xl: clamp(2.00rem, calc(1.61rem + 1.95vw), 3.38rem);
+    --space-xl-2xl: clamp(3.00rem, calc(2.58rem + 2.12vw), 4.50rem);
+    --space-2xl-3xl: clamp(4.00rem, calc(3.36rem + 3.22vw), 6.75rem);
 
-    /* animation */
-    --transition-base: 250ms ease;
-    --transition-movement: 200ms linear;
-    --transition-fade: 200ms ease;
+    /* ---- layout -------------------------------------------------------- */
+
+    --width-wide: 1440px;   /* full-bleed sections / hero content */
+    --width-page: 1200px;   /* default page shell */
+    --width-content: 760px; /* long-form reading column */
+    --gutter: var(--space-m-l);
+
+    /* ---- radii, borders, shadows --------------------------------------- */
+
+    --radius-xs: 4px;
+    --radius-s: 8px;
+    --radius-m: 14px;
+    --radius-l: 22px;
+    --radius-xl: 32px;
+    --radius-pill: 999px;
+    --radius-circle: 50%;
+
+    --border-width: 1px;
+    --border-radius: var(--radius-m); /* legacy alias, still used by markdown output */
+
+    --shadow-xs: 0 1px 2px color-mix(in srgb, var(--brand-indigo-ink) 8%, transparent);
+    --shadow-s: 0 2px 8px color-mix(in srgb, var(--brand-indigo-ink) 8%, transparent);
+    --shadow-m: 0 8px 24px color-mix(in srgb, var(--brand-indigo-ink) 10%, transparent);
+    --shadow-l: 0 18px 48px color-mix(in srgb, var(--brand-indigo-ink) 14%, transparent);
+
+    /* ---- motion --------------------------------------------------------- */
+
+    --transition-base: 220ms cubic-bezier(0.22, 0.61, 0.36, 1);
+    --transition-movement: 400ms cubic-bezier(0.22, 0.61, 0.36, 1);
+    --transition-fade: 180ms ease;
     --transition-bounce: 500ms cubic-bezier(0.5, 0.05, 0.2, 1.5);
 
-    /* focus */
-    --focus-outline: 0.3ch solid var( --nord13 );
+    /* ---- focus ---------------------------------------------------------- */
 
+    --focus-ring: 3px solid var(--brand-terracotta);
+    --focus-offset: 3px;
+    --focus-outline: var(--focus-ring); /* legacy alias */
+
+    /* ---- component sizing ------------------------------------------------ */
+
+    --header-height: 4.75rem;
+    --card-media-ratio: 3 / 2;
+    --card-media-ratio-tall: 4 / 5;
 }
 
-/* dark mode */
-:root[data-theme="dark"] {
+/* ---- dark mode --------------------------------------------------------- */
 
-    /* colours */
-    --background: var(--nord0);
-    --background-soft: var(--nord2);
-    --foreground: var(--nord6);
-    --foreground-soft: color-mix(in srgb, var(--nord6) 70%, var(--nord0));
-    --link: var(--nord8);
-    --link-hover: var(--nord6);
-    --divider: color-mix(in srgb, var(--nord6) 80%, var(--nord0));
+:root[data-theme='dark'] {
+    --surface: #16171f;
+    --surface-alt: #1d1f2a;
+    --surface-sunken: #101118;
+    --surface-raised: #22242f;
+    --surface-invert: var(--brand-cream);
+    --surface-accent: var(--brand-indigo);
 
-    /* syntax highlighting */
-    --code-background: var(--nord1);
+    --ink: #e8e6ef;
+    --ink-strong: #fbfaff;
+    --ink-muted: #a5a4b6;
+    --ink-faint: #7c7b8d;
+    --ink-invert: #16171f;
+    --ink-on-accent: var(--white);
+
+    --border: #2e3040;
+    --border-strong: #3f4256;
+    --divider: var(--border);
+
+    --accent: var(--brand-terracotta);
+    --accent-deep: #f0a870;
+    --accent-soft: var(--brand-blush);
+    --accent-wash: #262231;
+
+    --link: #a9b6e6;
+    --link-hover: var(--brand-terracotta);
+    --link-underline: color-mix(in srgb, #a9b6e6 40%, transparent);
+
+    --scrim: color-mix(in srgb, #000 55%, transparent);
+    --scrim-strong: color-mix(in srgb, #000 72%, transparent);
+
+    --footer-surface: #0e0f16;
+    --footer-ink: var(--ink);
+    --footer-heading: var(--accent);
+
+    --code-background: #10111a;
+    --code-inline-background: #262837;
+
+    --shadow-xs: 0 1px 2px rgb(0 0 0 / 40%);
+    --shadow-s: 0 2px 8px rgb(0 0 0 / 40%);
+    --shadow-m: 0 8px 24px rgb(0 0 0 / 45%);
+    --shadow-l: 0 18px 48px rgb(0 0 0 / 55%);
 }

--- a/src/en/pages/about.njk
+++ b/src/en/pages/about.njk
@@ -2,6 +2,8 @@
 layout: page
 title: About Us
 tags: 'about'
+eyebrow: Hello there
+byline: Two Vancouverites who kept saying yes to one more country. This is where we write it all down.
 draft: false
 seo:
   title: About Us
@@ -12,21 +14,26 @@ seo:
   noIndex: false
 ---
 
-<p>
-  Welcome to our travel blog! In 2022-23 we embarked on a nine month trip through Europe, and in 2025 we traveled through Southeast Asia. We will be sharing our trips, along with tips, guides, and recommendations from our experiences, so you don't make the same mistakes we did!
+<p class="lede">
+  Welcome to our travel blog! In 2022&ndash;23 we embarked on a nine month trip through Europe, and in 2025 we traveled through Southeast Asia. We share those trips along with the tips, guides, and recommendations we picked up along the way &mdash; so you don't make the same mistakes we did.
 </p>
 
-{% image "/assets/img/IMG_0237.jpg", "Photo of Daniela and Will on the coast of Portugal", "100vw", "Us on the coast of Portugal!", "rounded", "lazy", "auto", "async", "50", "50" %}
+{% image "/assets/img/IMG_0237.jpg", "Photo of Daniela and Will on the coast of Portugal", "(min-width: 60rem) 70vw, 100vw", "Us on the coast of Portugal!", "", "lazy", "auto", "async" %}
 
-<h3>Daniela</h3>
+<h2>Daniela</h2>
 <p>
-  Hello there! I have always loved exploring new places and learning about the world around me. Traveling has been a great way to do both. After traveling through Europe, I tried to balance my passion for travel with the reality of school while on a budget - which ultimately led me to write this blog.
+  Hello there! I have always loved exploring new places and learning about the world around me. Traveling has been a great way to do both. After traveling through Europe, I tried to balance my passion for travel with the reality of school while on a budget &mdash; which ultimately led me to write this blog.
 </p>
 
-<h3>Will</h3>
+<h2>Will</h2>
 <p>
-  Hey, I'm Will! I am the main web development force behind this blog, and some of the writing talent. I have always wanted to explore more of the world - and a nine month trip through Europe was a great place to start. Since going back to school for Computer Science, I had been itching to get out and see more of the world again, and Southeast Asia on a budget is a great way to do that! If you want to read more of my writing make sure to check out the more technologically, financially, and organizationally aimed articles, since that is where I shine.
+  Hey, I'm Will! I am the main web development force behind this blog, and some of the writing talent. I have always wanted to explore more of the world &mdash; and a nine month trip through Europe was a great place to start. Since going back to school for Computer Science, I had been itching to get out and see more of the world again, and Southeast Asia on a budget is a great way to do that! If you want to read more of my writing make sure to check out the more technologically, financially, and organizationally aimed articles, since that is where I shine.
 </p>
 <p>
   If you want to see more of my work check out <a href="https://williamvdg.me">my blog</a>, <a href="https://github.com/willtheorangeguy">my GitHub</a>, or for nerdy video content, there is <a href="https://youtube.com/c/willtheorangeguy">YouTube</a>.
 </p>
+
+<div class="callout callout--accent">
+  <p class="callout__title">Say hello</p>
+  <p>Questions about a route, a budget or a guide? Find us on <a href="https://www.instagram.com/danielaandwill">Instagram</a> &mdash; we answer everything.</p>
+</div>

--- a/src/en/pages/countries.njk
+++ b/src/en/pages/countries.njk
@@ -2,6 +2,7 @@
 layout: page
 title: Countries
 tags: 'countries'
+byline: Two continents, one long list of guides. Tap a continent on the map to jump to its posts.
 draft: false
 seo:
   title: Countries
@@ -12,6 +13,7 @@ seo:
   noIndex: false
 ---
 
+<div class="map-panel wide">
 <!--SVG MAP-->
     <section>
       <svg class="scale-svg-map" version="1.0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 468 239" preserveAspectRatio="xMidYMid meet">
@@ -103,128 +105,121 @@ seo:
         </a>
       </svg>
     </section>
+</div>
 
 <!--PAGE CONTENT-->
-{# 
-<div>
-  <h2 id="Africa">Africa</h2>
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-</div>
-#}
 
-<div>
-  <h2 id="Asia">Asia</h2>
-  <p>The trip we just finished - to take a quick break from university we decided to embark on a “shorter” four month and a bit trip throughout Southeast Asia, with Japan thrown in for Will. Travelling through the spring and summer months, we stayed in the warm weather and stuck to a budget, travelling to a side of the world neither of us has ever visited before.</p>
-</div>
-<div class="travel-guides-container-countries">
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/diy-lombok-loop/">Lombok by Motorbike</a></h3>
-        <h2 class="subtle" style="text-align: center;">Everything you need to know before riding around Lombok!</h2>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/en/writing/diy-lombok-loop/">{% image "/assets/img/posts/asia/lombokcover.jpeg", "", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
+<div class="wide">
+  <div class="section-header">
+    <p class="eyebrow">Continent</p>
+    <h2 class="section-header__title" id="Asia">Asia</h2>
+    <p>The trip we just finished &mdash; to take a quick break from university we decided to embark on a &ldquo;shorter&rdquo; four month and a bit trip throughout Southeast Asia, with Japan thrown in for Will. Travelling through the spring and summer months, we stayed in the warm weather and stuck to a budget, travelling to a side of the world neither of us has ever visited before.</p>
   </div>
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/komodo-island-tour/">Visit Komodo Island</a></h3>
-        <h2 class="subtle" style="text-align: center;">Everything you need to know before taking a tour!</h2>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/en/writing/komodo-island-tour/">{% image "/assets/img/posts/asia/komodocover.jpg", "", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
-  </div>
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/diy-the-ha-giang-loop/">DIY the Ha Giang Loop</a></h3>
-        <h2 class="subtle" style="text-align: center;">Everything you need to know for a succesful trip!</h2>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/en/writing/diy-the-ha-giang-loop/">{% image "/assets/img/posts/asia/cover.jpg", "", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
-  </div>
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/four-months-asia/">4 Months in Asia</a></h3>
-        <h2 class="subtle" style="text-align: center;">How we planned our Southeast Asia trip</h2>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/en/writing/four-months-asia/">{% image "/assets/img/posts/asia/IMG_2502.jpeg", "", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
-  </div>
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/one-week-japan-itinerary/">One Week in Japan</a></h3>
-        <h2 class="subtle" style="text-align: center;">How to visit Japan on a bougie backpacker budget!</h2>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/en/writing/one-week-japan-itinerary/">{% image "/assets/img/posts/asia/IMG_0495.jpg", "", "100vh", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
-  </div>
-</div>
 
-{# 
-<div>
-<h2 id="Australia">Australia</h2>
-<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-</div>
-#}
-
-<div>
-  <h2 id="Europe">Europe</h2>
-  <p>Our first and longest trip - we travelled through almost every country in Europe soon after graduating high school. We spent nine months backpacking through all different climates, and through the budget-friendly countries in Eastern Europe to expensive Switzerland. We tried to write for the blog during this trip, but there was so much to see and too many adventures to have, so we are catching up now.</p>
-</div>
-<div class="travel-guides-container-countries">
-    <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/nine-months-europe/">9 Months in Europe</a></h3>
-        <h2 class="subtle" style="text-align: center;">How we planned our Europe trip</h2>
-    </div>
-    <div>
-      <a style="text-decoration: none;" href="/en/writing/nine-months-europe/">{% image "/assets/img/posts/europe/IMG_7233.jpg", "Orange sunset over Norway Harbor", "100vw", "", "rounded", "lazy", "auto", "async", "", "" %}</a>
-    </div>
-  </div>
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/five-day-iceland-itinerary/">Iceland Itinerary</a></h3>
-        <h2 class="subtle" style="text-align: center;">A Five Day Iceland Itinerary</h2>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/en/writing/five-day-iceland-itinerary/">{% image "/assets/img/posts/europe/IMG_6788.jpg", "", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a></a>
-    </div>
+  <div class="grid grid--2">
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/diy-lombok-loop/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/asia/lombokcover.jpeg", "A waterfall in the hills of Lombok", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Indonesia</p>
+        <h3 class="card__title"><a href="/en/writing/diy-lombok-loop/">Lombok by Motorbike</a></h3>
+        <p class="card__excerpt">Everything you need to know before riding around Lombok!</p>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/komodo-island-tour/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/asia/komodocover.jpg", "Aerial shot of islands surrounded by beaches and blue water", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Indonesia</p>
+        <h3 class="card__title"><a href="/en/writing/komodo-island-tour/">Visit Komodo Island</a></h3>
+        <p class="card__excerpt">Everything you need to know before taking a tour around the Komodo Islands!</p>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/diy-the-ha-giang-loop/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/asia/cover.jpg", "Mountain road winding through northern Vietnam", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Vietnam</p>
+        <h3 class="card__title"><a href="/en/writing/diy-the-ha-giang-loop/">DIY the Ha Giang Loop</a></h3>
+        <p class="card__excerpt">Everything you need to know before doing this incredible ride!</p>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/four-months-asia/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/asia/IMG_2502.jpeg", "A view over Southeast Asia", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Itinerary</p>
+        <h3 class="card__title"><a href="/en/writing/four-months-asia/">4 Months in Southeast Asia</a></h3>
+        <p class="card__excerpt">An overview of how we planned and executed our four month trip through Southeast Asia!</p>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/one-week-japan-itinerary/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/asia/IMG_0495.jpg", "A street scene in Japan", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Japan</p>
+        <h3 class="card__title"><a href="/en/writing/one-week-japan-itinerary/">One Week in Japan</a></h3>
+        <p class="card__excerpt">How to visit Japan on a bougie backpacker budget!</p>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/nias-island/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/asia/niascover.jpeg", "Waves rolling into the coast of Nias", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Indonesia</p>
+        <h3 class="card__title"><a href="/en/writing/nias-island/">How to Visit Nias</a></h3>
+        <p class="card__excerpt">Everything you need to know before traveling to Nias, Indonesia!</p>
+      </div>
+    </article>
   </div>
 </div>
 
-{# 
-<div>
-<h2 id="SouthAmerica">South America</h2>
-<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-</div>
-#}
+<div class="wide">
+  <div class="section-header">
+    <p class="eyebrow">Continent</p>
+    <h2 class="section-header__title" id="Europe">Europe</h2>
+    <p>Our first and longest trip &mdash; we travelled through almost every country in Europe soon after graduating high school. We spent nine months backpacking through all different climates, and through the budget-friendly countries in Eastern Europe to expensive Switzerland. We tried to write for the blog during this trip, but there was so much to see and too many adventures to have, so we are catching up now.</p>
+  </div>
 
-<div>
-<h2 id="NorthAmerica">North America</h2>
-<p>We live in Canada, and sadly have visited North America the least, but spending almost all of our lives there, we know all sorts of deep insights, tips, and tricks - especially for those along the West Coast (or the “Wet Coast” as we like to call it in British Columbia) - however, we also made a pit stop in Boston, MA on our way back from Europe, so keep your eye out for that. Once we return from Southeast Asia, stay tuned for more local content!</p>
+  <div class="grid grid--2">
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/nine-months-europe/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/europe/IMG_7233.jpg", "Orange sunset over a Norwegian harbour", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Itinerary</p>
+        <h3 class="card__title"><a href="/en/writing/nine-months-europe/">9 Months in Europe</a></h3>
+        <p class="card__excerpt">An overview of how we planned and executed our entire nine month Europe trip!</p>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/five-day-iceland-itinerary/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/europe/IMG_6912.jpg", "An Icelandic landscape", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Iceland</p>
+        <h3 class="card__title"><a href="/en/writing/five-day-iceland-itinerary/">Five Days in Iceland</a></h3>
+        <p class="card__excerpt">Follow along with us as we travel through Iceland for five days!</p>
+      </div>
+    </article>
+  </div>
 </div>
-<!--
-<div class="travel-guides-container-countries">
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/iceland/">Iceland</a></h3>
-        <h2 class="subtle" style="text-align: center;">A One-Week Travel Guide</h2>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/iceland/">{% image "/assets/img/screenshots.png", "Screenshot of elva in VSCodium and the browser", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
+
+<div class="wide">
+  <div class="section-header">
+    <p class="eyebrow">Continent</p>
+    <h2 class="section-header__title" id="NorthAmerica">North America</h2>
+    <p>We live in Canada, and sadly have visited North America the least, but spending almost all of our lives there, we know all sorts of deep insights, tips, and tricks &mdash; especially for those along the West Coast (or the &ldquo;Wet Coast&rdquo; as we like to call it in British Columbia). We also made a pit stop in Boston, MA on our way back from Europe, so keep your eye out for that. Once we return from Southeast Asia, stay tuned for more local content!</p>
   </div>
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/iceland/">Iceland</a></h3>
-        <h2 class="subtle" style="text-align: center;">A One-Week Travel Guide</h2>
-    </div>
-    <div>
-      <a style="text-decoration: none;" href="/iceland/">{% image "/assets/img/screenshots.png", "Screenshot of elva in VSCodium and the browser", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
+
+  <div class="callout callout--accent">
+    <p class="callout__title">Coming soon</p>
+    <p>No guides published yet &mdash; we're writing them now. Subscribe by <a href="/en/feed/feed.xml">RSS</a> to catch the first one.</p>
   </div>
-</div>-->
+</div>

--- a/src/en/pages/tools.njk
+++ b/src/en/pages/tools.njk
@@ -2,6 +2,7 @@
 layout: page
 title: Tools
 tags: 'tools'
+byline: The spreadsheets, apps and services we actually use to plan a trip, keep it on budget and stay online.
 draft: false
 seo:
   title: Tools
@@ -12,31 +13,69 @@ seo:
   noIndex: false
 ---
 
-Check out the tools we use to plan our trips and travel the world! We have a few different categories of tools that we use, and we will be adding more as we go along. If you have any suggestions for tools that you think we should add, please let us know!
+<p>Check out the tools we use to plan our trips and travel the world! We have a few different categories of tools that we use, and we will be adding more as we go along. If you have any suggestions for tools that you think we should add, please let us know!</p>
 
-<br>
-<div class="travel-guides-container-countries">
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/vpns/">All About VPNs</a></h3>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/en/writing/vpns/">{% image "/assets/img/tools/vpns.JPG", "", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
+<div class="wide">
+  <div class="section-header">
+    <p class="eyebrow">Planning</p>
+    <h2 class="section-header__title">Spreadsheets and services</h2>
+  </div>
+  <div class="grid grid--2">
+
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/vpns/" tabindex="-1" aria-hidden="true">{% image "/assets/img/tools/vpns.JPG", "A laptop showing a VPN connection", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Privacy</p>
+        <h3 class="card__title"><a href="/en/writing/vpns/">All About VPNs</a></h3>
+        <p class="card__excerpt">VPNs are an important part of your online security toolkit &mdash; here's what they do and which one to pick.</p>
+      </div>
+    </article>
+
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/how-to-use-planning-sheets/" tabindex="-1" aria-hidden="true">{% image "/assets/img/tools/planning/main.png", "A travel planning spreadsheet", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Spreadsheets</p>
+        <h3 class="card__title"><a href="/en/writing/how-to-use-planning-sheets/">How to Use the Planning Sheets</a></h3>
+        <p class="card__excerpt">Maximise your time and see all the places, without the last-minute scramble.</p>
+      </div>
+    </article>
+
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/how-to-use-budget-sheets/" tabindex="-1" aria-hidden="true">{% image "/assets/img/tools/budget/sheet.png", "A travel budget spreadsheet", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Spreadsheets</p>
+        <h3 class="card__title"><a href="/en/writing/how-to-use-budget-sheets/">How to Use the Budget Sheets</a></h3>
+        <p class="card__excerpt">Track every euro and rupiah so the money lasts as long as the trip does.</p>
+      </div>
+    </article>
+
   </div>
 </div>
-<br>
-<div>
-  <h2>Reviews</h2>
-  <p>Every once in a while we find a product so good (or bad) that we have to write a review and share it!</p>
-</div>
-<div class="travel-guides-container-countries">
-  <div class="travel-guide-countries">
-    <div style="padding-bottom: 0.5em;">
-        <h3 class="center-text"><a style="text-decoration: none;" href="/en/writing/ltt-commuter-backpack-review/">LTT Commuter Backpack</a></h3>
-    </div>
-    <div>
-        <a style="text-decoration: none;" href="/en/writing/ltt-commuter-backpack-review/">{% image "/assets/img/posts/reviews/lttbagmain.JPG", "", "100vw", "", "rounded", "lazy", "auto", "async", "2400", "1600" %}</a>
-    </div>
+
+<div class="wide">
+  <div class="section-header">
+    <p class="eyebrow">Reviews</p>
+    <h2 class="section-header__title">Gear worth talking about</h2>
+    <p>Every once in a while we find a product so good (or bad) that we have to write a review and share it!</p>
+  </div>
+  <div class="grid grid--2">
+
+    <article class="card">
+      <div class="card__media">
+        <a href="/en/writing/ltt-commuter-backpack-review/" tabindex="-1" aria-hidden="true">{% image "/assets/img/posts/reviews/lttbagmain.JPG", "The LTT Commuter Backpack", "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}</a>
+      </div>
+      <div class="card__body">
+        <p class="eyebrow">Gear review</p>
+        <h3 class="card__title"><a href="/en/writing/ltt-commuter-backpack-review/">LTT Commuter Backpack</a></h3>
+        <p class="card__excerpt">One month of daily use on the road &mdash; what held up and what didn't.</p>
+      </div>
+    </article>
+
   </div>
 </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -135,7 +135,7 @@ seo:
 
         <div class="grid">
             {% for post in recent %}
-            <article class="card">
+            <article class="card{% if not post.data.heroImage %} card--minimal{% endif %}">
                 {% if post.data.heroImage %}
                 <div class="card__media">
                     {% image post.data.heroImage, post.data.heroImageAlt, "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}

--- a/src/index.njk
+++ b/src/index.njk
@@ -5,27 +5,225 @@ seo:
   title: Travel Blog & Travel Guides
   description: Daniela and Will's travel blog featuring travel guides and tips and tricks for a gap year throughout Europe or Asia.
 ---
+{%- set posts = collections.posts | languageFilter("en") | reverse -%}
+{%- set lead = posts[0] -%}
+{%- set secondary = posts.slice(1, 3) -%}
+{%- set recent = posts.slice(3, 9) -%}
+{%- set asiaPosts = collections.asia | languageFilter("en") -%}
+{%- set europePosts = collections.europe | languageFilter("en") -%}
+{%- set toolPosts = (collections.spreadsheets or []).concat(collections.tools or []) -%}
 
-<div class="home-hero">
-  <div class="home-hero-spacer"></div>
-  <div class="home-hero-content">
-    <p>
-        Welcome to our travel blog!<br>In 2022-23 we embarked on a nine month trip through Europe, and in 2025 we traveled through Southeast Asia. We will be sharing our trips, along with tips, guides, and recommendations from our experiences, so you don't make the same mistakes we did!
-    </p>
-  </div>
-</div>
-  {% set latestPosts = collections.posts | languageFilter("en") | reverse | batch(3) | first %}
-  <div class="travel-guides-container">
-    {% for post in latestPosts %}
-    <div class="travel-guide">
-      <div style="padding-bottom: 0.5em;">
-        <h1 class="center-text"><a style="text-decoration: none;" href="{{ post.url }}">{{ post.data.title }}</a></h1>
-        <h2 class="subtle" style="text-align: center;">{{ post.data.byline }}</h2>
-      </div>
-      <div>
-        <a style="text-decoration: none;" href="{{ post.url }}">{% image post.data.heroImage, post.data.heroImageAlt, "100vw", "", "rounded", "lazy", "auto", "async" %}</a>
-      </div>
+<!-- hero -->
+<section class="hero hero--center">
+    <div class="hero__media">
+        {% image "/assets/img/en.jpg", "A winding coastal road seen from above", "100vw", "", "", "eager", "high", "async" %}
     </div>
-    {% endfor %}
-  </div>
-</div>
+    <div class="hero__inner">
+        <div class="hero__content">
+            <span class="hero__script">Welcome to our travel blog</span>
+            <h1 class="hero__title">Two people, a long way from home.</h1>
+            <p class="hero__lede">In 2022&ndash;23 we spent nine months crossing Europe. In 2025 we rode, sailed and hiked our way through Southeast Asia. Here are the guides, budgets and hard-won lessons from both&nbsp;trips.</p>
+            <div class="hero__actions">
+                <a class="button button--accent" href="{{ "/countries/" | locale_url }}">Browse destinations</a>
+                <a class="button button--invert" href="{{ "/about/" | locale_url }}">Meet Daniela &amp; Will</a>
+            </div>
+        </div>
+    </div>
+    <p class="hero__credit">Like our photos? Find them on <a href="https://www.shutterstock.com/g/danielaasada">Shutter</a><a href="https://www.shutterstock.com/g/willtheorangeguy">stock</a>.</p>
+</section>
+
+<!-- latest guides -->
+{% if lead %}
+<section class="section">
+    <div class="shell">
+
+        <div class="section-header">
+            <p class="eyebrow">Fresh off the road</p>
+            <h2 class="section-header__title">Latest travel guides</h2>
+            <p>Everything we wish somebody had told us before we booked the flight.</p>
+        </div>
+
+        <div class="feature-row">
+
+            <article class="card feature-row__lead">
+                {% if lead.data.heroImage %}
+                <div class="card__media">
+                    {% image lead.data.heroImage, lead.data.heroImageAlt, "(min-width: 60rem) 60vw, 100vw", "", "", "lazy", "auto", "async" %}
+                </div>
+                {% endif %}
+                <div class="card__body">
+                    <p class="eyebrow">Newest guide</p>
+                    <h3 class="card__title"><a href="{{ lead.url }}">{{ lead.data.title }}</a></h3>
+                    {% if lead.data.byline %}<p class="card__excerpt">{{ lead.data.byline }}</p>{% endif %}
+                    <p class="card__meta">{{ lead.date | formatDate }}</p>
+                </div>
+            </article>
+
+            <div class="feature-row__aside">
+                {% for post in secondary %}
+                <article class="card card--horizontal">
+                    {% if post.data.heroImage %}
+                    <div class="card__media">
+                        {% image post.data.heroImage, post.data.heroImageAlt, "(min-width: 60rem) 20vw, 100vw", "", "", "lazy", "auto", "async" %}
+                    </div>
+                    {% endif %}
+                    <div class="card__body">
+                        <h3 class="card__title"><a href="{{ post.url }}">{{ post.data.title }}</a></h3>
+                        {% if post.data.byline %}<p class="card__excerpt subtle">{{ post.data.byline }}</p>{% endif %}
+                    </div>
+                </article>
+                {% endfor %}
+            </div>
+
+        </div>
+
+    </div>
+</section>
+{% endif %}
+
+<!-- destinations -->
+<section class="section section--tinted">
+    <div class="shell">
+
+        <div class="section-header section-header--center">
+            <p class="eyebrow">Where we've been</p>
+            <h2 class="section-header__title">Pick a corner of the world</h2>
+            <p>Two continents down, plenty to go. Every guide is written from a trip we actually took.</p>
+        </div>
+
+        <div class="grid grid--2">
+
+            <a class="tile" href="{{ "/countries/" | locale_url }}#Asia">
+                {% image "/assets/img/posts/asia/cover.jpg", "Limestone karsts rising out of the water in Southeast Asia", "(min-width: 60rem) 33vw, 100vw", "", "", "lazy", "auto", "async" %}
+                <span class="tile__label">
+                    <span class="tile__count">{{ asiaPosts.length }} guides</span>
+                    Southeast Asia
+                </span>
+            </a>
+
+            <a class="tile" href="{{ "/countries/" | locale_url }}#Europe">
+                {% image "/assets/img/posts/europe/IMG_7233.jpg", "A European street scene on a bright day", "(min-width: 60rem) 33vw, 100vw", "", "", "lazy", "auto", "async" %}
+                <span class="tile__label">
+                    <span class="tile__count">{{ europePosts.length }} guides</span>
+                    Europe
+                </span>
+            </a>
+
+            <div class="card card--boxed">
+                <div class="card__body">
+                    <p class="eyebrow">The whole map</p>
+                    <h3 class="card__title"><a href="{{ "/countries/" | locale_url }}">Every country we've written about</a></h3>
+                    <p class="card__excerpt">Tap a continent on the map to jump straight to the guides for it &mdash; itineraries, budgets and the routes we'd do again.</p>
+                    <p class="card__meta">Open the map &rarr;</p>
+                </div>
+            </div>
+
+        </div>
+
+    </div>
+</section>
+
+<!-- more reading -->
+{% if recent.length %}
+<section class="section">
+    <div class="shell">
+
+        <div class="section-header">
+            <p class="eyebrow">The archive</p>
+            <h2 class="section-header__title">More from the blog</h2>
+        </div>
+
+        <div class="grid">
+            {% for post in recent %}
+            <article class="card">
+                {% if post.data.heroImage %}
+                <div class="card__media">
+                    {% image post.data.heroImage, post.data.heroImageAlt, "(min-width: 60rem) 30vw, 100vw", "", "", "lazy", "auto", "async" %}
+                </div>
+                {% endif %}
+                <div class="card__body">
+                    <h3 class="card__title"><a href="{{ post.url }}">{{ post.data.title }}</a></h3>
+                    {% if post.data.byline %}<p class="card__excerpt">{{ post.data.byline }}</p>{% endif %}
+                    <p class="card__meta">{{ post.date | formatDate }}</p>
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+
+    </div>
+</section>
+{% endif %}
+
+<!-- tools -->
+{% if toolPosts.length %}
+<section class="section section--tinted">
+    <div class="shell">
+
+        <div class="section-header section-header--center">
+            <p class="eyebrow">Plan it properly</p>
+            <h2 class="section-header__title">Tools we actually use</h2>
+            <p>The spreadsheets, apps and services that kept our trips on budget and on schedule.</p>
+        </div>
+
+        <div class="grid">
+            {% for post in toolPosts %}
+            <article class="card card--boxed">
+                <div class="card__body">
+                    <p class="eyebrow">Tool</p>
+                    <h3 class="card__title"><a href="{{ post.url }}">{{ post.data.title }}</a></h3>
+                    {% if post.data.byline %}<p class="card__excerpt">{{ post.data.byline }}</p>{% endif %}
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+
+        <div class="section-header section-header--center" style="margin-top: var(--space-l); margin-bottom: 0;">
+            <div class="section-header__actions">
+                <a class="button button--outline" href="{{ "/tools/" | locale_url }}">See all tools</a>
+            </div>
+        </div>
+
+    </div>
+</section>
+{% endif %}
+
+<!-- meet us -->
+<section class="section">
+    <div class="shell">
+        <div class="feature-row">
+
+            <div class="card">
+                <div class="card__media" style="aspect-ratio: 16 / 10;">
+                    {% image "/assets/img/IMG_0237.jpg", "Daniela and Will on the coast of Portugal", "(min-width: 60rem) 60vw, 100vw", "", "", "lazy", "auto", "async" %}
+                </div>
+            </div>
+
+            <div class="feature-row__aside">
+                <div>
+                    <p class="eyebrow">Who's writing</p>
+                    <h2>Hey &mdash; we're Daniela and Will.</h2>
+                    <p class="lede" style="margin-top: var(--space-s);">We travel slowly, on a budget, and we write down everything we get wrong so you don't have to. Daniela plans the routes and the food. Will builds the spreadsheets and this website.</p>
+                    <p style="margin-top: var(--space-s);">
+                        <a class="button" href="{{ "/about/" | locale_url }}">Read our story</a>
+                    </p>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</section>
+
+<!-- newsletter -->
+<section class="section section--tight">
+    <div class="shell">
+        <div class="newsletter newsletter--invert">
+            <p class="eyebrow">Stay in touch</p>
+            <h2 class="newsletter__title">New guides, straight from the road</h2>
+            <p class="newsletter__lede">We post when we've actually got something worth saying &mdash; follow along on Instagram or grab the RSS feed.</p>
+            <div class="hero__actions">
+                <a class="button button--accent" href="https://www.instagram.com/danielaandwill">Follow on Instagram</a>
+                <a class="button button--invert" href="{{ "/feed/feed.xml" | locale_url }}">Subscribe by RSS</a>
+            </div>
+        </div>
+    </div>
+</section>

--- a/src/styleguide.njk
+++ b/src/styleguide.njk
@@ -76,6 +76,7 @@ seo:
             </ul>
             <p class="sg-nav__heading">Practice</p>
             <ul>
+                <li><a href="#i18n">Localisation</a></li>
                 <li><a href="#dodont">Do &amp; don't</a></li>
             </ul>
         </nav>
@@ -794,6 +795,51 @@ seo:
                 </table>
             </section>
 
+            <!-- ---------- localisation ---------- -->
+            <section class="sg-section" id="i18n">
+                <h2 class="sg-section__title">Localisation</h2>
+                <p class="sg-section__intro">The site is bilingual (English and Spanish) via <code>EleventyI18nPlugin</code>. Content lives under <code>src/en/</code> and <code>src/es/</code>; every string of interface chrome comes from <code>src/_data/translations.js</code>. Never hard-code UI text in a layout or include &mdash; a Spanish reader sees the same template you do.</p>
+
+                <table class="sg-table">
+                    <thead><tr><th>Filter</th><th>Use it for</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>translate</code></td><td>Any interface string. <code>{{ "{{ 'footer.explore' | translate }}" }}</code>. Supports substitution: <code>{{ "{{ 'post.by' | translate(page.lang, { author: author }) }}" }}</code>.</td></tr>
+                        <tr><td><code>locale_url</code></td><td>Internal links. Rewrites <code>/about/</code> to <code>/en/about/</code> or <code>/es/om/</code> depending on the page.</td></tr>
+                        <tr><td><code>localeFallback</code></td><td>Chain after <code>locale_url</code> for pages that exist in only one language. <code>locale_url</code> hands back an unprefixed, 404-ing URL when there is no translation; this restores the default-language prefix.</td></tr>
+                        <tr><td><code>languageFilter</code></td><td>Narrow a collection to one language before listing posts.</td></tr>
+                        <tr><td><code>formatDate</code></td><td>Dates already localise from <code>page.lang</code> &mdash; no extra work needed.</td></tr>
+                    </tbody>
+                </table>
+
+                {% set i18nMarkup %}
+&lt;!-- a link to a page that exists in both languages --&gt;
+&lt;a href="{{ "{{ '/about/' | locale_url }}" }}"&gt;{{ "{{ 'header.home' | translate }}" }}&lt;/a&gt;
+
+&lt;!-- a link to an English-only page, safe from every locale --&gt;
+&lt;a href="{{ "{{ '/affiliates/' | locale_url | localeFallback }}" }}"&gt;
+    {{ "{{ 'footer.affiliates' | translate }}" }}
+&lt;/a&gt;
+                {% endset %}
+                <div class="sg-story">
+                    <p class="sg-story__label">Linking<span class="sg-story__note">every internal link goes through a locale filter</span></p>
+                    <pre class="sg-code"><code>{{ i18nMarkup | safe }}</code></pre>
+                </div>
+
+                {% set langSwitchMarkup %}
+<div class="switch-language">
+    <a href="#" lang="en" hreflang="en" aria-label="EN: English" aria-current="page" class="current">EN</a>
+    <a href="#" lang="es" hreflang="es" aria-label="ES: Spanish">ES</a>
+    <span aria-label="FR: French" class="disabled">FR</span>
+</div>
+                {% endset %}
+                {{ story('Language switch', langSwitchMarkup, 'current locale is solid, available locales outline, untranslated pages dashed and disabled') }}
+
+                <div class="callout">
+                    <p class="callout__title">Adding a string</p>
+                    <p>Add the key to <strong>both</strong> the <code>en</code> and <code>es</code> blocks of <code>src/_data/translations.js</code>, then reference it with <code>translate</code>. A key missing from one language renders empty rather than falling back, so they must stay in step.</p>
+                </div>
+            </section>
+
             <!-- ---------- do / don't ---------- -->
             <section class="sg-section" id="dodont">
                 <h2 class="sg-section__title">Do &amp; don't</h2>
@@ -839,6 +885,14 @@ seo:
                     <div class="sg-dont">
                         <h4>Don't</h4>
                         <p>Hard-code a hex, px size or radius inside a component.</p>
+                    </div>
+                    <div class="sg-do">
+                        <h4>Do</h4>
+                        <p>Put interface text in <code>translations.js</code> and pull it with <code>translate</code>.</p>
+                    </div>
+                    <div class="sg-dont">
+                        <h4>Don't</h4>
+                        <p>Type English chrome straight into a layout &mdash; it leaks onto the Spanish pages.</p>
                     </div>
                 </div>
             </section>

--- a/src/styleguide.njk
+++ b/src/styleguide.njk
@@ -710,6 +710,11 @@ seo:
                     <pre class="sg-code"><code>{{ imageMarkup | escapeHtml | safe }}</code></pre>
                 </div>
 
+                <div class="callout callout--accent">
+                    <p class="callout__title">Photo credit overlay</p>
+                    <p>Passing a caption also makes the shortcode inject the Shutterstock credit chip &mdash; the <code>.bottom-left-text</code> pill in the bottom-right of the photo, linking to both of our portfolios. It is an affiliate placement, so <strong>don't remove it and don't skip the caption on our own photographs</strong>. A captioned figure becomes a two-row grid (image, then caption) with the chip sharing the image cell, which keeps it inside the photo no matter how long the caption runs. It hides below 48rem, where it would cover too much of the picture.</p>
+                </div>
+
                 <table class="sg-table" style="margin-top: var(--space-m);">
                     <thead><tr><th>Column</th><th>What lands there</th></tr></thead>
                     <tbody>

--- a/src/styleguide.njk
+++ b/src/styleguide.njk
@@ -1,0 +1,848 @@
+---
+layout: base
+seo:
+  title: Style Guide
+  description: The living style guide for Daniela and Will Travel — design tokens, typography, components and the markup that produces them.
+  excludeFromSitemap: true
+---
+{#
+    A storybook-style reference for the site. Every example below is rendered
+    with the real stylesheet, so if a component changes here it has changed
+    everywhere. Add a new component by writing a {% set %} block of markup and
+    passing it to the story() macro — the same string is rendered live and
+    printed as source.
+#}
+
+{%- macro story(label, markup, note = '', canvasClass = '') -%}
+<div class="sg-story">
+    <p class="sg-story__label">{{ label }}{% if note %}<span class="sg-story__note">{{ note }}</span>{% endif %}</p>
+    <div class="sg-canvas {{ canvasClass }}">
+        <div class="sg-canvas__inner">{{ markup | safe }}</div>
+    </div>
+    <pre class="sg-code"><code>{{ markup | escapeHtml | safe }}</code></pre>
+</div>
+{%- endmacro -%}
+
+{%- macro swatch(token, value) -%}
+<div class="sg-swatch">
+    <div class="sg-swatch__chip" style="background: var({{ token }});"></div>
+    <div class="sg-swatch__meta">
+        <span class="sg-swatch__name">{{ token }}</span>
+        <span class="sg-swatch__value">{{ value }}</span>
+    </div>
+</div>
+{%- endmacro -%}
+
+<header class="page-hero">
+    <div class="page-hero__inner">
+        <p class="eyebrow">Design system</p>
+        <h1 class="page-hero__title">Style Guide</h1>
+        <p class="page-hero__lede">Every token, component and markdown element used on Daniela and Will Travel, rendered with the live stylesheet. Copy the markup, keep the site consistent.</p>
+    </div>
+</header>
+
+<div class="shell">
+    <div class="sg">
+
+        <!-- ================= sidebar ================= -->
+        <nav class="sg-nav" aria-label="Style guide sections">
+            <p class="sg-nav__heading">Foundations</p>
+            <ul>
+                <li><a href="#principles">Principles</a></li>
+                <li><a href="#colour">Colour</a></li>
+                <li><a href="#typography">Typography</a></li>
+                <li><a href="#spacing">Spacing</a></li>
+                <li><a href="#shape">Radius &amp; shadow</a></li>
+            </ul>
+            <p class="sg-nav__heading">Components</p>
+            <ul>
+                <li><a href="#buttons">Buttons</a></li>
+                <li><a href="#labels">Eyebrows &amp; tags</a></li>
+                <li><a href="#sections">Sections &amp; grids</a></li>
+                <li><a href="#cards">Cards</a></li>
+                <li><a href="#tiles">Destination tiles</a></li>
+                <li><a href="#heroes">Heroes</a></li>
+                <li><a href="#callouts">Callouts &amp; notices</a></li>
+                <li><a href="#toc">Table of contents</a></li>
+                <li><a href="#forms">Forms</a></li>
+                <li><a href="#newsletter">Newsletter band</a></li>
+            </ul>
+            <p class="sg-nav__heading">Content</p>
+            <ul>
+                <li><a href="#prose">Markdown &amp; prose</a></li>
+                <li><a href="#images">Images</a></li>
+                <li><a href="#tables">Tables &amp; code</a></li>
+                <li><a href="#frontmatter">Post front matter</a></li>
+            </ul>
+            <p class="sg-nav__heading">Practice</p>
+            <ul>
+                <li><a href="#dodont">Do &amp; don't</a></li>
+            </ul>
+        </nav>
+
+        <!-- ================= body ================= -->
+        <div>
+
+            <!-- ---------- principles ---------- -->
+            <section class="sg-section" id="principles">
+                <h2 class="sg-section__title">Principles</h2>
+                <p class="sg-section__intro">Four rules that keep the site feeling like one place.</p>
+
+                <div class="grid grid--2">
+                    <div class="card card--boxed">
+                        <div class="card__body">
+                            <p class="eyebrow">01</p>
+                            <h3 class="card__title">Photographs carry the page</h3>
+                            <p class="card__excerpt">Big images, generous white space, no decorative borders. If a section feels flat, give the photo more room rather than adding ornament.</p>
+                        </div>
+                    </div>
+                    <div class="card card--boxed">
+                        <div class="card__body">
+                            <p class="eyebrow">02</p>
+                            <h3 class="card__title">One accent, used sparingly</h3>
+                            <p class="card__excerpt">Terracotta marks the single most important action in a view. Indigo does the everyday work. Everything else is ink on paper.</p>
+                        </div>
+                    </div>
+                    <div class="card card--boxed">
+                        <div class="card__body">
+                            <p class="eyebrow">03</p>
+                            <h3 class="card__title">Reading comes first</h3>
+                            <p class="card__excerpt">Body copy sits in a 760px column at a comfortable 1.7 line height. Images and embeds widen out; text never does.</p>
+                        </div>
+                    </div>
+                    <div class="card card--boxed">
+                        <div class="card__body">
+                            <p class="eyebrow">04</p>
+                            <h3 class="card__title">Tokens, not values</h3>
+                            <p class="card__excerpt">Never hard-code a colour, size or radius. Every value in the stylesheet resolves to a custom property so dark mode and rebrands stay cheap.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- ---------- colour ---------- -->
+            <section class="sg-section" id="colour">
+                <h2 class="sg-section__title">Colour</h2>
+                <p class="sg-section__intro">The palette comes straight from the hand-drawn logo: indigo ink, terracotta sun, blush, cream and mist. Brand tokens are raw values &mdash; always reference the semantic tokens in components so dark mode keeps working.</p>
+
+                <h3>Brand</h3>
+                <div class="sg-swatches">
+                    {{ swatch('--brand-indigo', '#5761a2') }}
+                    {{ swatch('--brand-indigo-deep', '#3c4478') }}
+                    {{ swatch('--brand-indigo-ink', '#232741') }}
+                    {{ swatch('--brand-terracotta', '#e99253') }}
+                    {{ swatch('--brand-terracotta-deep', '#c9702f') }}
+                    {{ swatch('--brand-blush', '#e1b09d') }}
+                    {{ swatch('--brand-cream', '#fbede3') }}
+                    {{ swatch('--brand-mist', '#d3dae8') }}
+                </div>
+
+                <h3 style="margin-top: var(--space-l);">Semantic</h3>
+                <p class="subtle">These are the ones to use. They swap automatically in dark mode.</p>
+                <div class="sg-swatches">
+                    {{ swatch('--surface', 'page background') }}
+                    {{ swatch('--surface-alt', 'tinted sections, cards') }}
+                    {{ swatch('--surface-invert', 'footer, dark blocks') }}
+                    {{ swatch('--ink', 'body text') }}
+                    {{ swatch('--ink-muted', 'secondary text') }}
+                    {{ swatch('--ink-faint', 'meta, captions') }}
+                    {{ swatch('--accent', 'primary accent') }}
+                    {{ swatch('--accent-deep', 'accent, text-safe') }}
+                    {{ swatch('--accent-wash', 'accent background') }}
+                    {{ swatch('--link', 'links') }}
+                    {{ swatch('--border', 'hairlines') }}
+                    {{ swatch('--border-strong', 'inputs, dividers') }}
+                    {{ swatch('--footer-surface', 'footer, dark in both themes') }}
+                    {{ swatch('--footer-heading', 'footer column headings') }}
+                </div>
+
+                <h3 style="margin-top: var(--space-l);">Signal</h3>
+                <div class="sg-swatches">
+                    {{ swatch('--signal-info', 'notices') }}
+                    {{ swatch('--signal-success', 'do') }}
+                    {{ swatch('--signal-warning', 'warnings') }}
+                    {{ swatch('--signal-danger', 'errors, don\'t') }}
+                </div>
+
+                <div class="callout" style="margin-top: var(--space-l);">
+                    <p class="callout__title">Contrast</p>
+                    <p>Terracotta on white does not pass AA for body text &mdash; use <code>--accent-deep</code> whenever the colour carries text, and reserve <code>--accent</code> for fills, rules and large display type.</p>
+                </div>
+            </section>
+
+            <!-- ---------- typography ---------- -->
+            <section class="sg-section" id="typography">
+                <h2 class="sg-section__title">Typography</h2>
+                <p class="sg-section__intro">Albert Sans does all the work: black weights with tight tracking for display, regular for reading, and small uppercase with wide tracking for labels. Bad Script &mdash; the logo lettering &mdash; appears only as an occasional flourish.</p>
+
+                <table class="sg-table">
+                    <thead>
+                        <tr><th>Token</th><th>Family</th><th>Used for</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><code>--font-display</code></td><td style="font-family: var(--font-display); font-weight: 800;">Albert Sans</td><td>Headings, buttons, labels, nav</td></tr>
+                        <tr><td><code>--font-body</code></td><td style="font-family: var(--font-body);">Albert Sans</td><td>Body copy and everything else</td></tr>
+                        <tr><td><code>--font-script</code></td><td style="font-family: var(--font-script); font-size: var(--step-1);">Bad Script</td><td>Wordmark, hero kicker. Never body copy.</td></tr>
+                        <tr><td><code>--font-mono</code></td><td style="font-family: var(--font-mono);">Fira Code</td><td>Code samples</td></tr>
+                    </tbody>
+                </table>
+
+                <h3 style="margin-top: var(--space-l);">Scale</h3>
+                <p class="subtle">Fluid from 320px to 1500px. Never set a font size in px.</p>
+                <div class="sg-specimen">
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step-7 · hero title · 800</span>
+                        <p class="sg-specimen__sample" style="font-size: var(--step-7); font-weight: 800; letter-spacing: var(--tracking-display);">A long way from home</p>
+                    </div>
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step-6 · h1 · 800</span>
+                        <p class="sg-specimen__sample" style="font-size: var(--step-6); font-weight: 800; letter-spacing: var(--tracking-display);">Nine months in Europe</p>
+                    </div>
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step-4 · h2 · 800</span>
+                        <p class="sg-specimen__sample" style="font-size: var(--step-4); font-weight: 800; letter-spacing: var(--tracking-display);">Latest travel guides</p>
+                    </div>
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step-3 · article h2 · 800</span>
+                        <p class="sg-specimen__sample" style="font-size: var(--step-3); font-weight: 800;">How to get there</p>
+                    </div>
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step-2 · h3 / card title · 800</span>
+                        <p class="sg-specimen__sample" style="font-size: var(--step-2); font-weight: 800;">What to look for in a tour</p>
+                    </div>
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step-1 · lede · 400</span>
+                        <p class="sg-specimen__sample" style="font-size: var(--step-1); font-weight: 400; color: var(--ink-muted);">Everything we wish somebody had told us before we booked the flight.</p>
+                    </div>
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step-0 · body · 400 · 1.7</span>
+                        <p class="sg-specimen__sample" style="font-size: var(--step-0); font-weight: 400; line-height: var(--leading-body);">There is no way to arrive directly in Komodo &mdash; instead you will need to fly or ferry into Labuan Bajo, a city on a nearby island.</p>
+                    </div>
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step--1 · meta, captions</span>
+                        <p class="sg-specimen__sample" style="font-size: var(--step--1); color: var(--ink-muted);">By Daniela and Will · 8 May 2025 · 9 minutes to read</p>
+                    </div>
+                    <div class="sg-specimen__row">
+                        <span class="sg-specimen__meta">--step--2 · eyebrow · 700 · uppercase</span>
+                        <p class="sg-specimen__sample eyebrow">Fresh off the road</p>
+                    </div>
+                </div>
+
+                {% set typeMarkup %}
+<p class="eyebrow">Fresh off the road</p>
+<h2>Latest travel guides</h2>
+<p class="lede">Everything we wish somebody had told us before we booked the flight.</p>
+<p class="script" style="font-size: var(--step-2);">Welcome to our travel blog</p>
+                {% endset %}
+                {{ story('Text styles', typeMarkup, 'eyebrow + heading + lede + script flourish') }}
+            </section>
+
+            <!-- ---------- spacing ---------- -->
+            <section class="sg-section" id="spacing">
+                <h2 class="sg-section__title">Spacing</h2>
+                <p class="sg-section__intro">One fluid scale for gaps, padding and rhythm. Pairs like <code>--space-m-l</code> grow between two steps as the viewport widens &mdash; use those for page gutters and section padding.</p>
+
+                <div class="sg-space">
+                    <div class="sg-space__row"><span>--space-3xs</span><div class="sg-space__bar" style="width: var(--space-3xs);"></div></div>
+                    <div class="sg-space__row"><span>--space-2xs</span><div class="sg-space__bar" style="width: var(--space-2xs);"></div></div>
+                    <div class="sg-space__row"><span>--space-xs</span><div class="sg-space__bar" style="width: var(--space-xs);"></div></div>
+                    <div class="sg-space__row"><span>--space-s</span><div class="sg-space__bar" style="width: var(--space-s);"></div></div>
+                    <div class="sg-space__row"><span>--space-m</span><div class="sg-space__bar" style="width: var(--space-m);"></div></div>
+                    <div class="sg-space__row"><span>--space-l</span><div class="sg-space__bar" style="width: var(--space-l);"></div></div>
+                    <div class="sg-space__row"><span>--space-xl</span><div class="sg-space__bar" style="width: var(--space-xl);"></div></div>
+                    <div class="sg-space__row"><span>--space-2xl</span><div class="sg-space__bar" style="width: var(--space-2xl);"></div></div>
+                    <div class="sg-space__row"><span>--space-3xl</span><div class="sg-space__bar" style="width: var(--space-3xl);"></div></div>
+                </div>
+
+                <table class="sg-table" style="margin-top: var(--space-l);">
+                    <thead><tr><th>Token</th><th>Where it is used</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>--gutter</code></td><td>Left/right page padding on every shell</td></tr>
+                        <tr><td><code>--width-page</code></td><td>1200px &mdash; default page shell</td></tr>
+                        <tr><td><code>--width-wide</code></td><td>1440px &mdash; heroes, full-bleed sections, article images</td></tr>
+                        <tr><td><code>--width-content</code></td><td>760px &mdash; the reading column</td></tr>
+                        <tr><td><code>--measure</code></td><td>68ch &mdash; maximum line length for standalone copy</td></tr>
+                    </tbody>
+                </table>
+            </section>
+
+            <!-- ---------- shape ---------- -->
+            <section class="sg-section" id="shape">
+                <h2 class="sg-section__title">Radius &amp; shadow</h2>
+                <p class="sg-section__intro">Soft but not bubbly. Cards and images use <code>--radius-m</code>; heroes and panels use <code>--radius-l</code>; anything interactive and pill-shaped uses <code>--radius-pill</code>.</p>
+
+                <div class="sg-radius-grid">
+                    <div class="sg-radius-demo" style="border-radius: var(--radius-xs);">xs</div>
+                    <div class="sg-radius-demo" style="border-radius: var(--radius-s);">s</div>
+                    <div class="sg-radius-demo" style="border-radius: var(--radius-m);">m</div>
+                    <div class="sg-radius-demo" style="border-radius: var(--radius-l);">l</div>
+                    <div class="sg-radius-demo" style="border-radius: var(--radius-xl);">xl</div>
+                    <div class="sg-radius-demo" style="border-radius: var(--radius-pill);">pill</div>
+                </div>
+
+                <div class="sg-shadow-grid" style="margin-top: var(--space-l);">
+                    <div class="sg-shadow-demo" style="box-shadow: var(--shadow-xs);">xs</div>
+                    <div class="sg-shadow-demo" style="box-shadow: var(--shadow-s);">s</div>
+                    <div class="sg-shadow-demo" style="box-shadow: var(--shadow-m);">m</div>
+                    <div class="sg-shadow-demo" style="box-shadow: var(--shadow-l);">l</div>
+                </div>
+            </section>
+
+            <!-- ---------- buttons ---------- -->
+            <section class="sg-section" id="buttons">
+                <h2 class="sg-section__title">Buttons</h2>
+                <p class="sg-section__intro">Pill-shaped, uppercase, wide tracking. One accent button per view &mdash; everything else is indigo, outline or ghost.</p>
+
+                {% set buttonMarkup %}
+<div class="cluster">
+    <a class="button" href="#">Read our story</a>
+    <a class="button button--accent" href="#">Browse destinations</a>
+    <a class="button button--outline" href="#">See all tools</a>
+    <a class="button button--ghost" href="#">Keep reading</a>
+</div>
+                {% endset %}
+                {{ story('Variants', buttonMarkup) }}
+
+                {% set buttonSizeMarkup %}
+<div class="cluster">
+    <a class="button button--small" href="#">Small</a>
+    <a class="button" href="#">Default</a>
+    <a class="button button--large" href="#">Large</a>
+    <a class="button" href="#" aria-disabled="true">Disabled</a>
+</div>
+                {% endset %}
+                {{ story('Sizes and states', buttonSizeMarkup) }}
+
+                {% set buttonInvertMarkup %}
+<div class="cluster">
+    <a class="button button--invert" href="#">On a photo</a>
+    <a class="button button--accent" href="#">Primary</a>
+</div>
+                {% endset %}
+                {{ story('On dark surfaces', buttonInvertMarkup, 'use --button--invert over photography and the footer', 'sg-canvas--dark') }}
+            </section>
+
+            <!-- ---------- labels ---------- -->
+            <section class="sg-section" id="labels">
+                <h2 class="sg-section__title">Eyebrows &amp; tags</h2>
+                <p class="sg-section__intro">The eyebrow is the small uppercase kicker that sits above almost every heading on the site. Tags are for post categories.</p>
+
+                {% set labelMarkup %}
+<p class="eyebrow">Where we've been</p>
+<p class="eyebrow eyebrow--muted">The archive</p>
+<div class="cluster" style="margin-top: 1rem;">
+    <span class="tag">southeast asia</span>
+    <span class="tag tag--accent">itinerary</span>
+    <span class="tag tag--solid">planning</span>
+    <a class="tag" href="#">japan</a>
+</div>
+                {% endset %}
+                {{ story('Eyebrow and tag', labelMarkup) }}
+
+                {% set metaMarkup %}
+<ul class="meta-line">
+    <li>By Daniela and Will</li>
+    <li><time datetime="2025-05-08">8 May 2025</time></li>
+    <li>9 minutes to read</li>
+</ul>
+                {% endset %}
+                {{ story('Meta line', metaMarkup, 'byline, date and reading time on every post') }}
+            </section>
+
+            <!-- ---------- sections ---------- -->
+            <section class="sg-section" id="sections">
+                <h2 class="sg-section__title">Sections &amp; grids</h2>
+                <p class="sg-section__intro">Pages are built from <code>.section</code> bands. Each holds a <code>.shell</code> for the max width and gutters, a <code>.section-header</code>, then content. Add <code>.section--tinted</code> to alternate the background.</p>
+
+                {% set sectionMarkup %}
+<section class="section section--tinted">
+    <div class="shell">
+        <div class="section-header section-header--center">
+            <p class="eyebrow">Where we've been</p>
+            <h2 class="section-header__title">Pick a corner of the world</h2>
+            <p>Two continents down, plenty to go.</p>
+        </div>
+        <div class="grid">
+            <!-- cards go here -->
+        </div>
+    </div>
+</section>
+                {% endset %}
+                {{ story('Section anatomy', sectionMarkup, 'the wrapper every home page block uses', 'sg-canvas--flush') }}
+
+                <table class="sg-table" style="margin-top: var(--space-m);">
+                    <thead><tr><th>Class</th><th>Behaviour</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>.grid</code></td><td>Auto-fill columns, min 17.5rem &mdash; the default 3-up card grid</td></tr>
+                        <tr><td><code>.grid--2</code></td><td>Wider minimum (22rem) for 2-up layouts</td></tr>
+                        <tr><td><code>.grid--4</code></td><td>Narrower minimum (13.5rem) for dense tile walls</td></tr>
+                        <tr><td><code>.feature-row</code></td><td>One large card beside a stacked column of small ones</td></tr>
+                        <tr><td><code>.cluster</code></td><td>Wrapping inline row &mdash; buttons, tags, meta</td></tr>
+                        <tr><td><code>.stack</code></td><td>Vertical rhythm between direct children</td></tr>
+                    </tbody>
+                </table>
+            </section>
+
+            <!-- ---------- cards ---------- -->
+            <section class="sg-section" id="cards">
+                <h2 class="sg-section__title">Cards</h2>
+                <p class="sg-section__intro">One card component, four shapes. The title link stretches across the whole card, so don't nest other links inside a card body.</p>
+
+                {% set cardMarkup %}
+<article class="card">
+    <div class="card__media">
+        <img src="/assets/img/posts/asia/komodocover.jpg" alt="Aerial shot of the Komodo Islands">
+    </div>
+    <div class="card__body">
+        <p class="eyebrow">Indonesia</p>
+        <h3 class="card__title"><a href="#">Komodo Island Tour</a></h3>
+        <p class="card__excerpt">Everything you need to know before taking a tour around the Komodo Islands!</p>
+        <p class="card__meta">8 May 2025</p>
+    </div>
+</article>
+                {% endset %}
+                {{ story('Standard post card', cardMarkup) }}
+
+                {% set cardHorizontalMarkup %}
+<article class="card card--horizontal">
+    <div class="card__media">
+        <img src="/assets/img/posts/asia/lombokcover.JPEG" alt="A waterfall in the hills of Lombok">
+    </div>
+    <div class="card__body">
+        <h3 class="card__title"><a href="#">Lombok by Motorbike</a></h3>
+        <p class="card__excerpt subtle">Everything you need to know before riding around Lombok!</p>
+    </div>
+</article>
+                {% endset %}
+                {{ story('Horizontal card', cardHorizontalMarkup, 'sidebars, related posts, search results') }}
+
+                {% set cardOverlayMarkup %}
+<article class="card card--overlay">
+    <div class="card__media">
+        <img src="/assets/img/posts/europe/IMG_7233.jpg" alt="Orange sunset over a Norwegian harbour">
+    </div>
+    <div class="card__body">
+        <p class="eyebrow">Itinerary</p>
+        <h3 class="card__title"><a href="#">Nine Months in Europe</a></h3>
+        <p class="card__excerpt">How we planned and executed our entire nine month Europe trip.</p>
+    </div>
+</article>
+                {% endset %}
+                {{ story('Overlay card', cardOverlayMarkup, 'for hero-adjacent features only — text over photography needs the scrim') }}
+
+                {% set cardBoxedMarkup %}
+<article class="card card--boxed">
+    <div class="card__body">
+        <p class="eyebrow">Tool</p>
+        <h3 class="card__title"><a href="#">How to Use the Budget Sheets</a></h3>
+        <p class="card__excerpt">Track every euro and rupiah so the money lasts as long as the trip does.</p>
+    </div>
+</article>
+                {% endset %}
+                {{ story('Boxed card', cardBoxedMarkup, 'text-only cards: tools, resources, calls to action') }}
+            </section>
+
+            <!-- ---------- tiles ---------- -->
+            <section class="sg-section" id="tiles">
+                <h2 class="sg-section__title">Destination tiles</h2>
+                <p class="sg-section__intro">Tall, image-led links used for continents and countries. Keep labels to two lines.</p>
+
+                {% set tileMarkup %}
+<div class="grid grid--4">
+    <a class="tile" href="#">
+        <img src="/assets/img/posts/asia/cover.jpg" alt="Mountain road in northern Vietnam">
+        <span class="tile__label">
+            <span class="tile__count">6 guides</span>
+            Southeast Asia
+        </span>
+    </a>
+    <a class="tile" href="#">
+        <img src="/assets/img/posts/europe/IMG_7233.jpg" alt="Orange sunset over a Norwegian harbour">
+        <span class="tile__label">
+            <span class="tile__count">2 guides</span>
+            Europe
+        </span>
+    </a>
+</div>
+                {% endset %}
+                {{ story('Tiles', tileMarkup) }}
+            </section>
+
+            <!-- ---------- heroes ---------- -->
+            <section class="sg-section" id="heroes">
+                <h2 class="sg-section__title">Heroes</h2>
+                <p class="sg-section__intro">Three header treatments: a photographic hero for the home page, a tinted text header for pages, and a centred editorial header for posts.</p>
+
+                {% set heroMarkup %}
+<section class="hero hero--center hero--compact">
+    <div class="hero__media">
+        <img src="/assets/img/en.jpg" alt="A winding coastal road seen from above">
+    </div>
+    <div class="hero__inner">
+        <div class="hero__content">
+            <span class="hero__script">Welcome to our travel blog</span>
+            <h1 class="hero__title">Two people, a long way from home.</h1>
+            <p class="hero__lede">Guides, budgets and hard-won lessons from Europe and Southeast Asia.</p>
+            <div class="hero__actions">
+                <a class="button button--accent" href="#">Browse destinations</a>
+                <a class="button button--invert" href="#">Meet Daniela &amp; Will</a>
+            </div>
+        </div>
+    </div>
+</section>
+                {% endset %}
+                {{ story('Photographic hero', heroMarkup, 'home page only', 'sg-canvas--flush') }}
+
+                {% set pageHeroMarkup %}
+<header class="page-hero">
+    <div class="page-hero__inner">
+        <p class="eyebrow">Design system</p>
+        <h1 class="page-hero__title">Style Guide</h1>
+        <p class="page-hero__lede">A tinted header for standard pages — supplied automatically by the page layout.</p>
+    </div>
+</header>
+                {% endset %}
+                {{ story('Page header', pageHeroMarkup, 'rendered by _layouts/page.njk from title, eyebrow and byline', 'sg-canvas--flush') }}
+
+                {% set postHeroMarkup %}
+<header class="post-hero">
+    <div class="post-hero__inner">
+        <ol class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li>asia</li>
+        </ol>
+        <h1 class="post-hero__title">Komodo Island Tour</h1>
+        <p class="post-hero__byline">Everything you need to know before taking a tour around the Komodo Islands!</p>
+        <ul class="meta-line post-hero__meta">
+            <li>By Daniela and Will</li>
+            <li><time datetime="2025-05-08">8 May 2025</time></li>
+            <li>9 minutes to read</li>
+        </ul>
+    </div>
+</header>
+                {% endset %}
+                {{ story('Post header', postHeroMarkup, 'rendered by _layouts/post.njk from front matter', 'sg-canvas--flush') }}
+            </section>
+
+            <!-- ---------- callouts ---------- -->
+            <section class="sg-section" id="callouts">
+                <h2 class="sg-section__title">Callouts &amp; notices</h2>
+                <p class="sg-section__intro">Notices are generated automatically from markdown blockquotes. Callouts are hand-written for tips, packing lists and budgets.</p>
+
+                {% set noticeSourceMarkup %}
+> ❕ Tip: Arrive in Labuan Bajo at least one day before with enough time to get everything sorted.
+
+> ⚠ Warning: The national park entry fee is not always included in the tour price.
+                {% endset %}
+                <div class="sg-story">
+                    <p class="sg-story__label">Notice<span class="sg-story__note">write this markdown &mdash; the notices transform builds the box</span></p>
+                    <div class="sg-canvas">
+                        <div class="sg-canvas__inner">
+                            <blockquote class="notice">
+                                <p><svg class="notice-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true"><path d="M320 576C461.4 576 576 461.4 576 320C576 178.6 461.4 64 320 64C178.6 64 64 178.6 64 320C64 461.4 178.6 576 320 576zM288 224C288 206.3 302.3 192 320 192C337.7 192 352 206.3 352 224C352 241.7 337.7 256 320 256C302.3 256 288 241.7 288 224zM280 288L328 288C341.3 288 352 298.7 352 312L352 400L360 400C373.3 400 384 410.7 384 424C384 437.3 373.3 448 360 448L280 448C266.7 448 256 437.3 256 424C256 410.7 266.7 400 280 400L304 400L304 336L280 336C266.7 336 256 325.3 256 312C256 298.7 266.7 288 280 288z"/></svg><span>Tip: Arrive in Labuan Bajo at least one day before with enough time to get everything sorted.</span></p>
+                            </blockquote>
+                            <br>
+                            <blockquote class="notice notice-warning">
+                                <p><svg class="notice-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true"><path d="M320 64C334.7 64 348.2 72.1 355.2 85L571.2 485C577.9 497.4 577.6 512.4 570.4 524.5C563.2 536.6 550.1 544 536 544L104 544C89.9 544 76.8 536.6 69.6 524.5C62.4 512.4 62.1 497.4 68.8 485L284.8 85C291.8 72.1 305.3 64 320 64zM320 416C302.3 416 288 430.3 288 448C288 465.7 302.3 480 320 480C337.7 480 352 465.7 352 448C352 430.3 337.7 416 320 416zM320 224C301.8 224 287.3 239.5 288.6 257.7L296 361.7C296.9 374.2 307.4 384 319.9 384C332.5 384 342.9 374.3 343.8 361.7L351.2 257.7C352.5 239.5 338.1 224 319.8 224z"/></svg><span>Warning: The national park entry fee is not always included in the tour price.</span></p>
+                            </blockquote>
+                        </div>
+                    </div>
+                    <pre class="sg-code"><code>{{ noticeSourceMarkup | escapeHtml | safe }}</code></pre>
+                </div>
+
+                {% set calloutMarkup %}
+<div class="callout callout--accent">
+    <p class="callout__title">What to pack</p>
+    <p>Reef-safe sunscreen, a dry bag and more cash than you think you need — there is no ATM on the boat.</p>
+</div>
+                {% endset %}
+                {{ story('Callout', calloutMarkup) }}
+
+                {% set calloutInvertMarkup %}
+<div class="callout callout--invert">
+    <p class="callout__title">Our verdict</p>
+    <p>Worth every rupiah. Book the overnight tour and sleep on the boat.</p>
+</div>
+                {% endset %}
+                {{ story('Callout, inverted', calloutInvertMarkup) }}
+            </section>
+
+            <!-- ---------- toc ---------- -->
+            <section class="sg-section" id="toc">
+                <h2 class="sg-section__title">Table of contents</h2>
+                <p class="sg-section__intro">Long guides open with a jump list. Wrap the heading and list in <code>.toc</code>.</p>
+
+                {% set tocMarkup %}
+<div class="toc">
+    <h3>Table of Contents</h3>
+    <ul>
+        <li><a href="#get-there">How to Get There</a></li>
+        <li><a href="#tour">What to Look for in a Tour</a></li>
+        <li><a href="#length">How Many Days</a></li>
+        <li><a href="#route">The Route</a></li>
+    </ul>
+</div>
+                {% endset %}
+                {{ story('Table of contents', tocMarkup) }}
+            </section>
+
+            <!-- ---------- forms ---------- -->
+            <section class="sg-section" id="forms">
+                <h2 class="sg-section__title">Forms</h2>
+                <p class="sg-section__intro">Pill-shaped inputs to match the buttons. Always pair an input with a visible label.</p>
+
+                {% set formMarkup %}
+<div class="stack">
+    <div class="field">
+        <label class="field__label" for="sg-email">Email address</label>
+        <input class="input" id="sg-email" type="email" placeholder="you@example.com">
+        <span class="field__hint">We only email when there's a new guide.</span>
+    </div>
+    <div class="field">
+        <label class="field__label" for="sg-select">Destination</label>
+        <select class="select" id="sg-select">
+            <option>Southeast Asia</option>
+            <option>Europe</option>
+        </select>
+    </div>
+    <div class="field">
+        <label class="field__label" for="sg-message">Message</label>
+        <textarea class="textarea" id="sg-message" placeholder="Ask us anything"></textarea>
+    </div>
+    <div class="field">
+        <label class="field__label" for="sg-error">Email address</label>
+        <input class="input input--invalid" id="sg-error" type="email" value="not-an-email">
+        <span class="field__error">That doesn't look like an email address.</span>
+    </div>
+</div>
+                {% endset %}
+                {{ story('Fields', formMarkup) }}
+            </section>
+
+            <!-- ---------- newsletter ---------- -->
+            <section class="sg-section" id="newsletter">
+                <h2 class="sg-section__title">Newsletter band</h2>
+                <p class="sg-section__intro">The closing block on the home page. Use the inverted variant when it follows a light section.</p>
+
+                {% set newsletterMarkup %}
+<div class="newsletter">
+    <p class="eyebrow">Stay in touch</p>
+    <h2 class="newsletter__title">New guides, straight from the road</h2>
+    <p class="newsletter__lede">We post when we've actually got something worth saying.</p>
+    <form class="newsletter__form">
+        <div class="field">
+            <label class="field__label screen-reader-text" for="sg-news">Email address</label>
+            <input class="input" id="sg-news" type="email" placeholder="you@example.com">
+        </div>
+        <button class="button button--accent" type="submit">Subscribe</button>
+    </form>
+    <p class="newsletter__note">No spam. Unsubscribe whenever.</p>
+</div>
+                {% endset %}
+                {{ story('Newsletter', newsletterMarkup, '', 'sg-canvas--flush') }}
+            </section>
+
+            <!-- ---------- prose ---------- -->
+            <section class="sg-section" id="prose">
+                <h2 class="sg-section__title">Markdown &amp; prose</h2>
+                <p class="sg-section__intro">Everything inside a post body is wrapped in <code>.prose</code>. It is a named-line grid: text sits in the <code>content</code> column (760px), figures and embeds widen to <code>wide</code> (1440px), and anything with <code>.bleed</code> spans the full viewport. Plain markdown needs no wrapper divs.</p>
+
+                <div class="sg-canvas sg-canvas--flush">
+                    <div class="prose" style="padding-block: var(--space-m);">
+                        <h2>How to get there</h2>
+                        <p>There is no way to arrive directly in Komodo &mdash; instead you will need to fly or ferry into <a href="#">Labuan Bajo</a>, a city on a nearby island. There are many flight options available, leaving from Jakarta, Bali, or Lombok, so pick whatever fits best with your itinerary.</p>
+                        <h3>Getting around once you land</h3>
+                        <p>Prices in person are much better than online &mdash; just make sure you have enough cash. We ended up getting an overnight, semi-private tour for <strong>1,600,000 IDR</strong> per person.</p>
+                        <ul>
+                            <li>One day tours feel rushed and you miss sunset.</li>
+                            <li>Overnight tours include a bed on the boat.</li>
+                            <li>Ask about the park fee <em>before</em> you pay.</li>
+                        </ul>
+                        <ol>
+                            <li>Arrive in Labuan Bajo a day early.</li>
+                            <li>Walk the main street and compare three operators.</li>
+                            <li>Pay in cash, get a receipt.</li>
+                        </ol>
+                        <blockquote>
+                            <p>We would do this again in a heartbeat — but we would book the overnight boat.</p>
+                            <cite>Daniela</cite>
+                        </blockquote>
+                        <h4>A smaller heading</h4>
+                        <p>Inline code looks like <code>--space-m</code>, and <mark>highlighted text</mark> uses the accent wash. Small print sits in <small>a smaller size</small>.</p>
+                        <hr>
+                        <p class="subtle">A muted closing note, set with <code>.subtle</code>.</p>
+                    </div>
+                </div>
+
+                {% set proseMarkup %}
+<article class="hentry post">
+    <header class="post-hero">…</header>
+    <div class="entry-content prose">
+        <!-- markdown output drops straight in here -->
+    </div>
+    <footer class="post-footer">…</footer>
+</article>
+                {% endset %}
+                {{ story('Article shell', proseMarkup, 'the structure _layouts/post.njk produces', 'sg-canvas--tinted') }}
+            </section>
+
+            <!-- ---------- images ---------- -->
+            <section class="sg-section" id="images">
+                <h2 class="sg-section__title">Images</h2>
+                <p class="sg-section__intro">Always use the <code>image</code> shortcode &mdash; it generates AVIF/WebP, responsive sizes and the figure wrapper. Inside a post it automatically widens past the text column.</p>
+
+                {% set imageMarkup %}
+{&#37; image "/assets/img/posts/asia/komodocover.jpg",
+   "Aerial shot of islands surrounded by beaches and blue water",
+   "100vw",
+   "Beautiful aerial shot of the Komodo Islands",
+   "",
+   "lazy", "auto", "async" &#37;}
+                {% endset %}
+                <div class="sg-story">
+                    <p class="sg-story__label">Figure with caption<span class="sg-story__note">src, alt, sizes, caption, classes, loading, fetchpriority, decoding</span></p>
+                    <div class="sg-canvas">
+                        <div class="sg-canvas__inner">
+                            {% image "/assets/img/posts/asia/komodocover.jpg", "Aerial shot of islands surrounded by beaches and blue water", "(min-width: 60rem) 60vw, 100vw", "Beautiful aerial shot of the Komodo Islands", "", "lazy", "auto", "async" %}
+                        </div>
+                    </div>
+                    <pre class="sg-code"><code>{{ imageMarkup | escapeHtml | safe }}</code></pre>
+                </div>
+
+                <table class="sg-table" style="margin-top: var(--space-m);">
+                    <thead><tr><th>Column</th><th>What lands there</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>content</code></td><td>Paragraphs, headings, lists, quotes, callouts &mdash; the default</td></tr>
+                        <tr><td><code>wide</code></td><td><code>figure</code>, embeds and any element with <code>.wide</code></td></tr>
+                        <tr><td><code>full</code></td><td>Elements with <code>.bleed</code> &mdash; edge-to-edge, use rarely</td></tr>
+                    </tbody>
+                </table>
+            </section>
+
+            <!-- ---------- tables ---------- -->
+            <section class="sg-section" id="tables">
+                <h2 class="sg-section__title">Tables &amp; code</h2>
+                <p class="sg-section__intro">Tables scroll horizontally on small screens rather than squashing. Code blocks use the indigo-ink background from the syntax theme.</p>
+
+                {% set tableMarkup %}
+<table>
+    <thead>
+        <tr><th>Route</th><th>Duration</th><th>Cost (IDR)</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>Labuan Bajo &rarr; Padar</td><td>4 hours</td><td>1,600,000</td></tr>
+        <tr><td>Padar &rarr; Pink Beach</td><td>1 hour</td><td>included</td></tr>
+        <tr><td>Park entry fee</td><td>&mdash;</td><td>600,000</td></tr>
+    </tbody>
+</table>
+                {% endset %}
+                {{ story('Table', tableMarkup) }}
+
+                <div class="sg-story">
+                    <p class="sg-story__label">Code block</p>
+                    <div class="sg-canvas">
+                        <div class="sg-canvas__inner">
+<pre class="language-css"><code class="language-css"><span class="token selector">.card__title a</span> <span class="token punctuation">{</span>
+    <span class="token property">color</span><span class="token punctuation">:</span> inherit<span class="token punctuation">;</span>
+    <span class="token property">text-decoration</span><span class="token punctuation">:</span> none<span class="token punctuation">;</span>
+<span class="token punctuation">}</span></code></pre>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- ---------- front matter ---------- -->
+            <section class="sg-section" id="frontmatter">
+                <h2 class="sg-section__title">Post front matter</h2>
+                <p class="sg-section__intro">The layouts read these keys. <code>byline</code> and <code>heroImage</code> are what make a post look right in the card grids &mdash; never ship a post without them.</p>
+
+                {% set frontMatterMarkup %}
+---
+layout: post
+title: Komodo Island Tour
+date: 2025-05-08
+author: Daniela and Will
+tags:
+ - asia
+ - southeast-asia
+ - planning
+draft: false
+byline: Everything you need to know before taking a tour around the Komodo Islands!
+heroImage: /assets/img/posts/asia/komodocover.jpg
+heroImageAlt: Aerial shot of islands surrounded by beaches and blue water
+seo:
+  title: The Best Way to Visit the Komodo Islands in 2025
+  description: Everything you need to know before taking a tour from Labuan Bajo.
+  changeFrequency: yearly
+---
+                {% endset %}
+                <div class="sg-story">
+                    <p class="sg-story__label">Required keys</p>
+                    <pre class="sg-code"><code>{{ frontMatterMarkup | escapeHtml | safe }}</code></pre>
+                </div>
+
+                <table class="sg-table">
+                    <thead><tr><th>Key</th><th>Where it shows up</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>title</code></td><td>Post header, card titles, browser tab</td></tr>
+                        <tr><td><code>byline</code></td><td>Post lede and every card excerpt</td></tr>
+                        <tr><td><code>heroImage</code> / <code>heroImageAlt</code></td><td>Card media on the home page, countries page and related posts</td></tr>
+                        <tr><td><code>tags</code></td><td>Breadcrumb (first tag) and the tag pills in the post footer</td></tr>
+                        <tr><td><code>seo.title</code> / <code>seo.description</code></td><td>Title tag, meta description, Open Graph</td></tr>
+                        <tr><td><code>eyebrow</code></td><td>Pages only &mdash; the kicker above the page title</td></tr>
+                    </tbody>
+                </table>
+            </section>
+
+            <!-- ---------- do / don't ---------- -->
+            <section class="sg-section" id="dodont">
+                <h2 class="sg-section__title">Do &amp; don't</h2>
+                <p class="sg-section__intro">The mistakes that will make a new page look off-brand.</p>
+
+                <div class="sg-do-dont">
+                    <div class="sg-do">
+                        <h4>Do</h4>
+                        <p>Use <code>--accent-deep</code> when terracotta carries text.</p>
+                    </div>
+                    <div class="sg-dont">
+                        <h4>Don't</h4>
+                        <p>Set body copy in <code>--accent</code> &mdash; it fails contrast on white.</p>
+                    </div>
+                    <div class="sg-do">
+                        <h4>Do</h4>
+                        <p>Give every section an eyebrow and a heading.</p>
+                    </div>
+                    <div class="sg-dont">
+                        <h4>Don't</h4>
+                        <p>Stack two tinted sections in a row &mdash; alternate them.</p>
+                    </div>
+                    <div class="sg-do">
+                        <h4>Do</h4>
+                        <p>Reach for the <code>image</code> shortcode for every photograph.</p>
+                    </div>
+                    <div class="sg-dont">
+                        <h4>Don't</h4>
+                        <p>Drop in a bare <code>&lt;img&gt;</code> &mdash; it skips the responsive sizes.</p>
+                    </div>
+                    <div class="sg-do">
+                        <h4>Do</h4>
+                        <p>Use the script face for one short flourish per page.</p>
+                    </div>
+                    <div class="sg-dont">
+                        <h4>Don't</h4>
+                        <p>Set headings or paragraphs in Bad Script &mdash; it is unreadable at length.</p>
+                    </div>
+                    <div class="sg-do">
+                        <h4>Do</h4>
+                        <p>Add new values as tokens in <code>variables.css</code> and document them here.</p>
+                    </div>
+                    <div class="sg-dont">
+                        <h4>Don't</h4>
+                        <p>Hard-code a hex, px size or radius inside a component.</p>
+                    </div>
+                </div>
+            </section>
+
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Complete visual overhaul in the vein of [saltinourhair.com](https://www.saltinourhair.com) — full-bleed photography, generous whitespace, big tight-tracked display type, small uppercase labels — while keeping our own branding: the indigo / terracotta / blush / cream / mist palette pulled from the logo, Albert Sans for type, and Bad Script kept as an occasional script flourish rather than a heading face.

All existing markdown transfers over unchanged. No post bodies were edited.

## Design system

`src/assets/css/variables.css` is now a real token layer — brand palette, semantic `surface`/`ink`/`accent` tokens, fluid type scale, spacing scale, radii, shadows, motion, focus. Components reference semantics only, so dark mode is a token swap rather than a second stylesheet.

Also fixes the `@font-face` `format()` declarations, which said `format('ttf')` instead of `format('truetype')` — the local Albert Sans and Bad Script files were never actually loading.

The stylesheet is split into one file per component:

| File | Contains |
| --- | --- |
| `components/button.css` | Pill buttons — solid, accent, outline, ghost, invert, sizes |
| `components/navigation.css` | Sticky header, mobile slide-down menu |
| `components/hero.css` | Photographic hero, page header, post header, breadcrumb |
| `components/card.css` | Post card, overlay, horizontal, boxed, destination tile, feature row |
| `components/prose.css` | Article body, table of contents, callouts, post footer |
| `components/newsletter.css` | Subscribe band and form controls |
| `components/footer.css` | Multi-column footer |
| `components/styleguide.css` | Chrome for `/styleguide/` only |

Article bodies use a named-line grid, so plain markdown needs no wrapper divs: text sits in a 760px reading column, `figure` and embeds widen out to 1440px, and anything marked `.bleed` spans the full viewport.

## Templates

- **Header** — sticky, hairline-bottom, logo left, uppercase links right; collapses to a slide-down panel below 60rem.
- **Footer** — multi-column with the script wordmark, link groups, theme switch. Keeps its own colour pair so it stays dark in both themes.
- **Home** — photographic hero, feature row, destination tiles with guide counts, archive grid, tools strip, meet-us block, closing subscribe band.
- **Post** — centred editorial header with breadcrumb, byline and meta line; tag pills and a related-posts strip at the foot.
- **Page** — tinted header driven by `title` / `eyebrow` / `byline`.
- **Countries, tools, about, 404** — rebuilt on the new card and section components.

## Style guide

New public page at **`/styleguide/`** (`src/styleguide.njk`) documenting tokens, typography, spacing, radius/shadow, every component, the markdown/prose reference, post front matter and a do/don't list.

Each example is rendered with the live stylesheet next to the escaped markup that produced it, so the guide cannot drift from the site. Adding a story is:

```njk
{% set myMarkup %}
<a class="button" href="#">Browse destinations</a>
{% endset %}
{{ story('Label', myMarkup, 'optional note') }}
```

Three small Eleventy filters support this: `exclude` (drop the current page from a collection), `withoutTags` (strip Eleventy's structural tags), and `escapeHtml` (render markup as source).

## Verification

Built and checked in a real browser at 1440px and 390px, in light and dark mode:

- Home, post, countries, tools, about, 404, style guide and the markdown kitchen-sink page
- Zero horizontal overflow at either width
- Notices, affiliate grid, image figures, tables, code blocks and nested lists all render correctly from existing markdown
- Mobile menu opens and closes; theme switch works in both directions


---
_Generated by [Claude Code](https://claude.ai/code/session_01STKcHiq7Y3okcc4Umdax2g)_