### PR TITLE
fix(seo): eager LCP hero, tag-aware related posts, thin-tag noindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ key **fails the build** rather than quietly producing a broken card.
 ---
 title: One Week Japan Itinerary
 date: 2025-03-10
-modified: 2025-03-10
 author: Daniela
 tags:
  - asia
@@ -124,9 +123,27 @@ the last three are what make a post look right in the card grids on the home
 page, the countries page and the related-posts strip. `seo` is optional; set
 `seo.slug` to override the URL slug, which otherwise comes from the filename.
 
+`modified` is optional and deliberately so. It feeds `dateModified` in the
+post's JSON-LD and `lastmod` in the sitemap, so **only add it when the content
+actually changed** — refreshed prices, a new visa rule, a rewritten section.
+Omitted, both fall back to `date`, which is the honest answer for a post that
+has never been revised. Don't mirror `date` into it; the schema rejects a
+`modified` earlier than `date`. It is not derived from the filesystem on
+purpose: `actions/checkout` stamps every file with the clone time, and a git
+last-commit date moves for build-only commits, so either would announce a
+refresh that never happened.
+
 Every tag becomes an archive page at `/<lang>/tag/<tag>/` automatically. Add a
 display override to `TAG_LABEL_OVERRIDES` in `src/lib/format.ts` for any tag
-that doesn't survive plain title casing (`vpn` → `VPN`).
+that doesn't survive plain title casing (`vpn` → `VPN`). A tag holding fewer
+than `MIN_INDEXABLE_TAG_POSTS` posts (`src/lib/posts.ts`, currently 3) still
+gets a page, but it is served `noindex, follow` and kept out of the sitemap — a
+one-post archive is a near-duplicate of the post it lists and competes with it.
+Tags cross the threshold on their own as posts accumulate.
+
+Tags also drive the related-posts strip: it recommends the three posts sharing
+the most tags with the current one, spreading links so no post is left without
+inbound links. Tagging accurately is what makes that work.
 
 ### Images
 
@@ -146,6 +163,14 @@ import Figure from '@components/Figure.astro';
 `Figure` generates AVIF, WebP and original-format variants at several widths.
 **Passing a `caption` also renders the Shutterstock photo credit chip** — it is
 an affiliate placement, so don't skip the caption on our own photographs.
+
+Images lazy-load by default. **The first `Figure` in a post must carry
+`priority`** — it is the one above the fold, and a lazy image isn't discovered
+until layout decides it is near the viewport, which is exactly what makes it a
+slow Largest Contentful Paint. `priority` sets `loading="eager"` and
+`fetchpriority="high"` together. Use it on exactly one image per page; marking
+several is the same as marking none, because they compete with each other.
+`npm test` fails the build if a post's hero isn't eager.
 
 Files in `public/` are copied as-is and are *not* optimized; that folder is for
 icons, fonts and downloads only.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "astro preview",
     "check": "astro check",
     "clean": "rimraf dist .astro node_modules/.astro",
-    "test": "node tests/theme-persistence.test.mjs"
+    "test": "node tests/theme-persistence.test.mjs && node tests/seo.test.mjs"
   },
   "author": {
     "name": "Daniela Sada and William Vandergraaf",

--- a/src/components/Figure.astro
+++ b/src/components/Figure.astro
@@ -20,6 +20,19 @@ interface Props {
     caption?: string;
     /** Class applied to the <img>. */
     class?: string;
+    /**
+     * Marks this as the page's LCP image.
+     *
+     * A lazy image is not discovered until layout decides it is near the
+     * viewport, and the browser cannot prioritize what it has not discovered —
+     * so the one image above the fold has to opt out of lazy loading. Sets
+     * `loading="eager"` and `fetchpriority="high"` together, because either
+     * alone leaves the fetch behind the rest of the page.
+     *
+     * Exactly one image per page should carry it: marking several is the same
+     * as marking none, since they then compete with each other.
+     */
+    priority?: boolean;
     loading?: 'lazy' | 'eager';
     fetchpriority?: 'high' | 'low' | 'auto';
     decoding?: 'async' | 'sync' | 'auto';
@@ -31,8 +44,10 @@ const {
     sizes = '100vw',
     caption = '',
     class: className = '',
-    loading = 'lazy',
-    fetchpriority = 'auto',
+    priority = false,
+    // `priority` sets both of these; passing either explicitly still wins.
+    loading = priority ? 'eager' : 'lazy',
+    fetchpriority = priority ? 'high' : 'auto',
     decoding = 'async'
 } = Astro.props;
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -47,6 +47,16 @@ const posts = defineCollection({
         thumbnailDescription: z.string().optional(),
         seo
     })
+        // `modified` is an editorial claim that the post was revised, and it is
+        // the only thing feeding JSON-LD `dateModified` and sitemap `lastmod`.
+        // Deriving it from the filesystem instead was considered and rejected:
+        // `actions/checkout` stamps every file with the clone time, and a git
+        // last-commit date moves for build-only commits too — both would report
+        // a refresh that never happened. Omit it until the content really changes.
+        .refine((data) => !data.modified || data.modified >= data.date, {
+            message: 'modified is earlier than date — a post cannot be revised before it was published',
+            path: ['modified']
+        })
 });
 
 // Editorial pages (about, tools, the legal set) are .astro files under

--- a/src/content/posts/en/asia/diy-lombok-loop.mdx
+++ b/src/content/posts/en/asia/diy-lombok-loop.mdx
@@ -1,7 +1,6 @@
 ---
 title: Lombok by Motorbike
 date: 2025-05-12
-modified: 2025-05-12
 author: Daniela and Will
 tags:
  - asia
@@ -20,7 +19,7 @@ seo:
 import Figure from '@components/Figure.astro';
 
 
-<Figure src="/assets/img/posts/asia/lombokcover.jpeg" alt="Mt. Rinjani rising over a beach between the clouds" sizes="100vw" caption="Mt. Rinjani rising over a beach between the clouds" class="rounded" />
+<Figure priority src="/assets/img/posts/asia/lombokcover.jpeg" alt="Mt. Rinjani rising over a beach between the clouds" sizes="100vw" caption="Mt. Rinjani rising over a beach between the clouds" class="rounded" />
 
 While we don't think our _Lombok Loop_ will get ever as popular as the [Ha Giang Loop](/en/writing/diy-the-ha-giang-loop/) (and honestly, we hope it won't), here is the best way to travel around the island of Lombok and experience everything it has to offer.
 

--- a/src/content/posts/en/asia/diy-the-ha-giang-loop.mdx
+++ b/src/content/posts/en/asia/diy-the-ha-giang-loop.mdx
@@ -1,7 +1,6 @@
 ---
 title: DIY the Ha Giang Loop
 date: 2025-04-02
-modified: 2025-04-02
 author: Daniela and Will
 tags:
  - asia
@@ -20,7 +19,7 @@ seo:
 import Figure from '@components/Figure.astro';
 
 
-<Figure src="/assets/img/posts/asia/cover.jpg" alt="Road carving through the mountains" sizes="100vw" caption="Road carving through the mountains" class="rounded" />
+<Figure priority src="/assets/img/posts/asia/cover.jpg" alt="Road carving through the mountains" sizes="100vw" caption="Road carving through the mountains" class="rounded" />
 
 Everything you need to know before doing this incredible ride on your own.
 

--- a/src/content/posts/en/asia/four-months-asia.mdx
+++ b/src/content/posts/en/asia/four-months-asia.mdx
@@ -1,7 +1,6 @@
 ---
 title: Four Months in Southeast Asia
 date: 2025-02-16
-modified: 2025-02-16
 author: Daniela and Will
 tags:
  - asia
@@ -21,7 +20,7 @@ seo:
 import Figure from '@components/Figure.astro';
 
 
-<Figure src="/assets/img/posts/asia/IMG_2502.jpeg" alt="Us on the coast of Cambodia" sizes="100vw" caption="Relaxing off the coast of Cambodia" class="rounded" />
+<Figure priority src="/assets/img/posts/asia/IMG_2502.jpeg" alt="Us on the coast of Cambodia" sizes="100vw" caption="Relaxing off the coast of Cambodia" class="rounded" />
 
 Asia quite literally takes us to the other side of the world, since Canada is home. This trip has just begun, and we plan to explore this part of the globe over the next 4-5 months. Here we will document our current plan and update as we go along, as well as adding any tips and recommendations we learn.
 

--- a/src/content/posts/en/asia/komodo-island-tour.mdx
+++ b/src/content/posts/en/asia/komodo-island-tour.mdx
@@ -1,7 +1,6 @@
 ---
 title: Komodo Island Tour
 date: 2025-05-08
-modified: 2025-05-08
 author: Daniela and Will
 tags:
  - asia
@@ -31,7 +30,7 @@ Everything you need to know BEFORE going to Komodo National Park!
 - [What to Bring](#packing)
 - [The Komodo Dragon](#dragon)
 
-<Figure src="/assets/img/posts/asia/komodocover.jpg" alt="Arial shot of islands surrounded by beaches and blue water" sizes="100vw" caption="Beautiful arial shot of the Komodo Islands" class="rounded" />
+<Figure priority src="/assets/img/posts/asia/komodocover.jpg" alt="Arial shot of islands surrounded by beaches and blue water" sizes="100vw" caption="Beautiful arial shot of the Komodo Islands" class="rounded" />
 
 <h2 id="get-there">How to Get There</h2>
 

--- a/src/content/posts/en/asia/nias-island.mdx
+++ b/src/content/posts/en/asia/nias-island.mdx
@@ -1,7 +1,6 @@
 ---
 title: How to Visit Nias
 date: 2025-06-02
-modified: 2025-06-02
 author: Daniela
 tags:
  - asia
@@ -20,7 +19,7 @@ seo:
 import Figure from '@components/Figure.astro';
 
 
-<Figure src="/assets/img/posts/asia/niascover.jpeg" alt="Palm trees near the sea on Nias Island" sizes="100vw" caption="Palm trees near the sea on Nias Island" class="rounded" />
+<Figure priority src="/assets/img/posts/asia/niascover.jpeg" alt="Palm trees near the sea on Nias Island" sizes="100vw" caption="Palm trees near the sea on Nias Island" class="rounded" />
 
 Nias is an island off the coast of Sumatra, that over the years has become difficult to access. We stayed on the little island for one week, volunteering through Worldpackers.
 

--- a/src/content/posts/en/asia/one-week-japan-itinerary.mdx
+++ b/src/content/posts/en/asia/one-week-japan-itinerary.mdx
@@ -1,7 +1,6 @@
 ---
 title: One Week Japan Itinerary
 date: 2025-03-10
-modified: 2025-03-10
 author: Daniela
 tags:
  - asia
@@ -22,7 +21,7 @@ seo:
 import Figure from '@components/Figure.astro';
 
 
-<Figure src="/assets/img/posts/asia/IMG_0495.jpg" alt="Shinto temple in Tokyo with smoke in front of it" sizes="100vw" caption="Shinto Temple in Tokyo" class="rounded" />
+<Figure priority src="/assets/img/posts/asia/IMG_0495.jpg" alt="Shinto temple in Tokyo with smoke in front of it" sizes="100vw" caption="Shinto Temple in Tokyo" class="rounded" />
 
 Japan has become THE travel destination of the year, with everyone and their dog pining for a chance to go. We had the privilege to visit early this year in January and managed to do it without breaking the bank.
 

--- a/src/content/posts/en/europe/five-day-iceland-itinerary.mdx
+++ b/src/content/posts/en/europe/five-day-iceland-itinerary.mdx
@@ -25,7 +25,7 @@ The world's largest volcanic island, Iceland is a land of fire and ice. With thi
 Here is what we did in our time in Iceland, along with some tips based on our experience.
 
 <div style="transform: rotate(180deg);">
-<Figure src="/assets/img/posts/europe/IMG_6912.jpg" alt="An Icelandic landscape" sizes="100vw" class="rounded" />
+<Figure priority src="/assets/img/posts/europe/IMG_6912.jpg" alt="An Icelandic landscape" sizes="100vw" class="rounded" />
 </div>
 
 ## Arriving in Iceland

--- a/src/content/posts/en/europe/nine-months-europe.mdx
+++ b/src/content/posts/en/europe/nine-months-europe.mdx
@@ -1,7 +1,6 @@
 ---
 title: Nine Months in Europe
 date: 2025-02-16
-modified: 2025-02-16
 author: Daniela and Will
 tags:
  - europe
@@ -22,7 +21,7 @@ import Figure from '@components/Figure.astro';
 
 Planning a long trip is no easy feat, it requires weeks of research and preparation, all in hope that everything works out. This article aims to ease the stress that comes along with planning a multi-month trip to Europe, specifically nine months as we did in 2022-2023.
 
-<Figure src="/assets/img/posts/europe/IMG_7233.jpg" alt="Orange sunset over Norway Harbor" sizes="100vw" caption="Orange sunset over Norwegian Harbour" class="rounded" />
+<Figure priority src="/assets/img/posts/europe/IMG_7233.jpg" alt="Orange sunset over Norway Harbor" sizes="100vw" caption="Orange sunset over Norwegian Harbour" class="rounded" />
 
 ### Table of Contents
 

--- a/src/content/posts/en/reviews/ltt-commuter-backpack-review.mdx
+++ b/src/content/posts/en/reviews/ltt-commuter-backpack-review.mdx
@@ -23,7 +23,7 @@ Obviously, the main point of a commuter backpack is not to travel to SEA for fou
 
 I received my bag on January 17, 2025 (the beauty of living in Langley, BC), and left for Japan on January 20.
 
-<Figure src="/assets/img/posts/reviews/lttbagmain.JPG" alt="The bag at a Japanese temple" sizes="100vw" caption="The bag at a Japanese temple" class="rounded" />
+<Figure priority src="/assets/img/posts/reviews/lttbagmain.JPG" alt="The bag at a Japanese temple" sizes="100vw" caption="The bag at a Japanese temple" class="rounded" />
 
 ## Loadout
 

--- a/src/content/posts/en/tools/how-to-use-budget-sheets.mdx
+++ b/src/content/posts/en/tools/how-to-use-budget-sheets.mdx
@@ -1,7 +1,6 @@
 ---
 title: How to Use the Budget Sheets
 date: 2025-04-20
-modified: 2025-04-20
 author: Will
 tags:
  - planning
@@ -31,7 +30,7 @@ I created three separate sheets, to organize expenses before and during the trip
 
 ### Budget by Country
 
-<Figure src="/assets/img/tools/budget/sheet.png" alt="A budget planning spreadsheet open in Google Sheets" sizes="100vw" class="rounded" />
+<Figure priority src="/assets/img/tools/budget/sheet.png" alt="A budget planning spreadsheet open in Google Sheets" sizes="100vw" class="rounded" />
 
 The first sheet lists all of the countries, and creates a budget for each one. There are five different categories of expenses, each one with a sub-item for whether Daniela or I bought it.
 

--- a/src/content/posts/en/tools/how-to-use-planning-sheets.mdx
+++ b/src/content/posts/en/tools/how-to-use-planning-sheets.mdx
@@ -1,7 +1,6 @@
 ---
 title: How to Use the Planning Sheets
 date: 2025-04-20
-modified: 2025-04-20
 author: Will
 tags:
  - planning
@@ -31,7 +30,7 @@ When we went to Europe, the spreadsheet was split into three columns, because of
 
 ### The Main Page
 
-<Figure src="/assets/img/tools/planning/main.png" alt="A trip itinerary planning spreadsheet open in Google Sheets" sizes="100vw" class="rounded" />
+<Figure priority src="/assets/img/tools/planning/main.png" alt="A trip itinerary planning spreadsheet open in Google Sheets" sizes="100vw" class="rounded" />
 
 I suggest starting with a _main_ or _table of contents_ style sheet, which lists the arrival and departure dates for each country/state/territory you are going to visit, the name (obviously), and how long you are going to spend there.
 

--- a/src/content/posts/en/tools/vpns.mdx
+++ b/src/content/posts/en/tools/vpns.mdx
@@ -1,7 +1,6 @@
 ---
 title: All About VPNs
 date: 2025-04-20
-modified: 2025-04-20
 author: Will
 tags:
  - tools
@@ -21,7 +20,7 @@ import Figure from '@components/Figure.astro';
 
 While it may sound like an advertisement, a VPN really is super important while abroad. Let me break down what a VPN is, what it allows you to do, and why you should get one!
 
-<Figure src="/assets/img/tools/vpns.jpg" alt="A collection of computers and phones on a table." sizes="100vw" class="rounded" />
+<Figure priority src="/assets/img/tools/vpns.jpg" alt="A collection of computers and phones on a table." sizes="100vw" class="rounded" />
 
 ## What is a VPN?
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -19,6 +19,13 @@ interface Props {
     image?: string;
     imageAlt?: string;
     noIndex?: boolean;
+    /**
+     * Robots directive used when `noIndex` is set. Defaults to blocking both,
+     * but a page kept out of the index for being thin — a one-post tag archive
+     * — still wants its links crawled, so it asks for `noindex, follow`.
+     * Staging always wins over this.
+     */
+    robots?: string;
     /** Extra classes on <body>; the old templates used the tag list here. */
     bodyClass?: string;
     /** One or more schema.org objects, emitted as ld+json. */
@@ -32,6 +39,7 @@ const {
     image,
     imageAlt,
     noIndex = false,
+    robots = 'noindex, nofollow',
     bodyClass = '',
     jsonLd
 } = Astro.props;
@@ -47,6 +55,9 @@ const pathname = Astro.url.pathname;
 const canonical = absoluteUrl(pathname, settings.url);
 const socialImage = absoluteUrl(image ?? settings.meta.opengraphDefaultImage, settings.url);
 const socialImageAlt = imageAlt ?? translate('meta.opengraphDefaultAlt');
+
+// Staging is blocked outright; otherwise only a page that asked to be.
+const robotsContent = settings.isStaging ? 'noindex, nofollow' : noIndex ? robots : null;
 
 const alternates = localeLinks(pathname, lang);
 const structuredData = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
@@ -126,7 +137,7 @@ const manifest = localeUrl('/site.webmanifest', lang);
         <link rel="manifest" href={manifest} />
         <meta name="theme-color" media="(prefers-color-scheme: light)" content={settings.themeColorLight} />
         <meta name="theme-color" media="(prefers-color-scheme: dark)" content={settings.themeColorDark} />
-        {(settings.isStaging || noIndex) && <meta name="robots" content="noindex, nofollow" />}
+        {robotsContent && <meta name="robots" content={robotsContent} />}
 
         {
             structuredData.map((entry) => (

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -103,8 +103,74 @@ export async function getTagIndex(lang?: Lang): Promise<TagEntry[]> {
     );
 }
 
-/** Up to `count` other posts in the same language, newest first. */
-export async function getRelatedPosts(post: Post, count = 3): Promise<Post[]> {
-    const posts = await getPosts(langOf(post));
-    return posts.filter((candidate) => candidate.id !== post.id).slice(0, count);
+/**
+ * A tag archive earns its place in the index by collecting posts. Below this
+ * many it is a near-duplicate of the one post it lists, and the two compete
+ * with each other for the same query.
+ */
+export const MIN_INDEXABLE_TAG_POSTS = 3;
+
+/** Whether a tag archive is too thin to be worth indexing on its own. */
+export function isThinTag(entry: TagEntry): boolean {
+    return entry.posts.length < MIN_INDEXABLE_TAG_POSTS;
+}
+
+/**
+ * The related-posts strip for every post in a language, keyed by post id.
+ *
+ * Built in one pass for the whole language rather than per page, because the
+ * two things it has to balance pull against each other and only the second is
+ * visible from a single post:
+ *
+ *  1. Relevance. Candidates are ranked by how many editorial tags they share
+ *     with the post being rendered.
+ *  2. Coverage. This module is the site's main source of internal links, and
+ *     internal links are its own vote for what each page is about. It used to
+ *     recommend "the newest three posts that aren't this one", so the three most
+ *     recent articles collected every link on the site and the rest were
+ *     reachable only from the country index. Ranking by tags alone fixes the
+ *     topic mismatch but still strands whichever posts sit on unpopular tags.
+ *
+ * So among candidates tied on shared tags, the one recommended least often so
+ * far wins. `getPosts` is newest-first and `Array.prototype.sort` is stable, so
+ * recency remains the final tie-break.
+ */
+export async function getRelatedIndex(lang: Lang, count = 3): Promise<Map<string, Post[]>> {
+    const posts = await getPosts(lang);
+    const tagsOf = new Map(posts.map((post) => [post.id, new Set(editorialTags(post))]));
+    const timesRecommended = new Map(posts.map((post) => [post.id, 0]));
+    const index = new Map<string, Post[]>();
+
+    for (const post of posts) {
+        const mine = tagsOf.get(post.id)!;
+        const candidates = posts
+            .filter((candidate) => candidate.id !== post.id)
+            .map((candidate) => ({
+                post: candidate,
+                shared: [...tagsOf.get(candidate.id)!].filter((tag) => mine.has(tag)).length
+            }));
+
+        const picks: Post[] = [];
+        const taken = new Set<string>();
+
+        while (picks.length < count && taken.size < candidates.length) {
+            const [best] = candidates
+                .filter((candidate) => !taken.has(candidate.post.id))
+                .sort(
+                    (a, b) =>
+                        b.shared - a.shared ||
+                        timesRecommended.get(a.post.id)! - timesRecommended.get(b.post.id)!
+                );
+
+            if (!best) break;
+
+            picks.push(best.post);
+            taken.add(best.post.id);
+            timesRecommended.set(best.post.id, timesRecommended.get(best.post.id)! + 1);
+        }
+
+        index.set(post.id, picks);
+    }
+
+    return index;
 }

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -11,22 +11,31 @@ import type { GetStaticPaths } from 'astro';
 import { render } from 'astro:content';
 
 import Post from '@layouts/Post.astro';
-import { getPosts, getRelatedPosts, postLang, postUrl } from '@lib/posts';
+// Aliased: `Post` is the layout component imported above.
+import { getPosts, getRelatedIndex, postLang, postUrl, type Post as PostEntry } from '@lib/posts';
 
 export const getStaticPaths = (async () => {
     const posts = await getPosts();
 
-    return Promise.all(
-        posts.map(async (post) => ({
-            // Astro wants the rest param without its leading or trailing slash.
-            params: { slug: postUrl(post).slice(1, -1) },
-            props: {
-                post,
-                lang: postLang(post),
-                related: await getRelatedPosts(post)
-            }
-        }))
-    );
+    // Resolved once per language rather than once per page: the related strip
+    // spreads internal links across the whole archive, so it cannot be decided
+    // from inside a single post.
+    const related = new Map<string, PostEntry[]>();
+    for (const lang of new Set(posts.map(postLang))) {
+        for (const [id, picks] of await getRelatedIndex(lang)) {
+            related.set(id, picks);
+        }
+    }
+
+    return posts.map((post) => ({
+        // Astro wants the rest param without its leading or trailing slash.
+        params: { slug: postUrl(post).slice(1, -1) },
+        props: {
+            post,
+            lang: postLang(post),
+            related: related.get(post.id) ?? []
+        }
+    }));
 }) satisfies GetStaticPaths;
 
 const { post, lang, related } = Astro.props;

--- a/src/pages/[lang]/tag/[tag].astro
+++ b/src/pages/[lang]/tag/[tag].astro
@@ -13,7 +13,7 @@ import Card from '@components/Card.astro';
 
 import type { Lang } from '@data/locales';
 import { t } from '@lib/i18n';
-import { getTagIndex, type TagEntry } from '@lib/posts';
+import { getTagIndex, isThinTag, type TagEntry } from '@lib/posts';
 
 export const getStaticPaths = (async () => {
     const index = await getTagIndex();
@@ -34,6 +34,10 @@ const lang = entry.lang as Lang;
 const translate = t(lang);
 
 const count = entry.posts.length;
+
+// A tag holding one or two posts says nothing its posts don't already say, so
+// it stays out of the index — but `follow` keeps it passing equity to them.
+const thin = isThinTag(entry);
 const lede =
     count === 1
         ? translate('tags.countOne', { tag: entry.label })
@@ -46,6 +50,8 @@ const lede =
     lang={lang}
     image={entry.posts[0]?.data.heroImage}
     imageAlt={entry.posts[0]?.data.heroImageAlt}
+    noIndex={thin}
+    robots="noindex, follow"
 >
     <header class="page-hero">
         <div class="page-hero__inner">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,11 +62,10 @@ const jsonLd = [
     <section class="hero hero--center">
         <div class="hero__media">
             <Figure
+                priority
                 src="/assets/img/en.jpg"
                 alt="A winding coastal road seen from above"
                 sizes="100vw"
-                loading="eager"
-                fetchpriority="high"
             />
         </div>
         <div class="hero__inner">

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -3,7 +3,7 @@ import type { APIRoute } from 'astro';
 import { settings } from '@data/settings.js';
 import { absoluteUrl } from '@lib/i18n';
 import { toRfc3339 } from '@lib/format';
-import { getPosts, getTagIndex, postUrl } from '@lib/posts';
+import { getPosts, getTagIndex, isThinTag, postUrl } from '@lib/posts';
 
 interface PageMetaExport {
     changeFrequency?: string;
@@ -74,6 +74,11 @@ export const GET: APIRoute = async () => {
 
     // --- tag archives -------------------------------------------------------
     for (const entry of tagIndex) {
+        // Thin archives are noindexed by the tag template; submitting a URL we
+        // ask Google not to index is a contradiction it reports back as an
+        // error, so they are left out here too.
+        if (isThinTag(entry)) continue;
+
         const newest = entry.posts[0];
         entries.push({
             loc: absoluteUrl(`/${entry.lang}/tag/${entry.slug}/`, settings.url),

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -1,0 +1,154 @@
+// Regression tests for the SEO fixes that only exist in the built output.
+//
+// These assert against dist/ rather than the source, because every one of them
+// is a property of the emitted HTML: whether the LCP image is discoverable,
+// which posts the related strip actually links to, and what a thin tag archive
+// tells robots. Run `npm run build` first.
+import fs from 'node:fs';
+import path from 'node:path';
+
+let passed = 0;
+let failed = 0;
+
+function check(name, condition, detail = '') {
+    if (condition) {
+        passed++;
+        console.log(`PASS  ${name}`);
+    } else {
+        failed++;
+        console.error(`FAIL  ${name}${detail ? ` — ${detail}` : ''}`);
+    }
+}
+
+if (!fs.existsSync('dist/index.html')) {
+    console.error('No build found. Run `npm run build` before `npm test`.');
+    process.exit(1);
+}
+
+/** Every built post page, as [slug, html]. */
+const postDir = 'dist/en/writing';
+const posts = fs
+    .readdirSync(postDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => [entry.name, fs.readFileSync(path.join(postDir, entry.name, 'index.html'), 'utf8')]);
+
+check('found the built post pages', posts.length >= 12, `saw ${posts.length}`);
+
+// --- H1: the LCP image must be discoverable ---------------------------------
+//
+// The hero is the first <img> in document order on a post page. Lazy defers its
+// discovery until layout runs, which is exactly what made it the slow LCP.
+for (const [slug, html] of posts) {
+    const firstImg = html.match(/<img\b[^>]*>/);
+    check(
+        `${slug}: hero image is eager`,
+        firstImg && /loading="eager"/.test(firstImg[0]) && /fetchpriority="high"/.test(firstImg[0]),
+        firstImg ? firstImg[0].slice(0, 120) : 'no <img> found'
+    );
+
+    // Exactly one: several high-priority images compete and none of them wins.
+    const eager = html.match(/<img\b[^>]*loading="eager"[^>]*>/g) ?? [];
+    check(`${slug}: exactly one eager image`, eager.length === 1, `saw ${eager.length}`);
+}
+
+const homeFirstImg = fs.readFileSync('dist/index.html', 'utf8').match(/<img\b[^>]*>/);
+check(
+    'home page hero is still eager',
+    homeFirstImg && /loading="eager"/.test(homeFirstImg[0]) && /fetchpriority="high"/.test(homeFirstImg[0]),
+    homeFirstImg ? homeFirstImg[0].slice(0, 120) : 'no <img> found'
+);
+
+// --- H2: related posts must not be the same three everywhere ----------------
+//
+// The related strip is the last section of the article; count how often each
+// post is recommended across the whole site.
+const recommended = new Map();
+for (const [slug, html] of posts) {
+    const section = html.split('section--tinted')[1] ?? '';
+    const links = new Set([...section.matchAll(/href="(\/en\/writing\/[^"]+)"/g)].map((m) => m[1]));
+
+    check(`${slug}: recommends 3 posts`, links.size === 3, `saw ${links.size}`);
+    check(`${slug}: does not recommend itself`, !links.has(`/en/writing/${slug}/`));
+
+    for (const link of links) recommended.set(link, (recommended.get(link) ?? 0) + 1);
+}
+
+// The property the selection actually guarantees: no post is left without an
+// inbound link from the strip, and none of them absorbs a disproportionate
+// share. The old static widget gave three posts 12 each and everything else 0.
+// The exact spread moves with the tag graph, so assert the shape, not figures.
+const orphans = posts.map(([slug]) => slug).filter((slug) => !recommended.has(`/en/writing/${slug}/`));
+check('every post is recommended somewhere', orphans.length === 0, orphans.join(', '));
+
+const worst = Math.max(...recommended.values());
+check(
+    'no post absorbs more than half the related links',
+    worst <= Math.ceil(posts.length / 2),
+    `worst = ${worst}`
+);
+
+// The concrete regression from the audit: an Iceland post recommending three
+// Indonesian islands.
+const iceland = posts.find(([slug]) => slug === 'five-day-iceland-itinerary');
+if (iceland) {
+    const section = iceland[1].split('section--tinted')[1] ?? '';
+    const indonesian = ['nias-island', 'diy-lombok-loop', 'komodo-island-tour'].filter((slug) =>
+        section.includes(`/en/writing/${slug}/`)
+    );
+    check(
+        'iceland post is not recommending the full Indonesia set',
+        indonesian.length < 3,
+        `matched ${indonesian.join(', ')}`
+    );
+}
+
+// --- H3: thin tag archives are noindex,follow and out of the sitemap --------
+const tagDir = 'dist/en/tag';
+const sitemap = fs.readFileSync('dist/sitemap.xml', 'utf8');
+
+for (const entry of fs.readdirSync(tagDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const html = fs.readFileSync(path.join(tagDir, entry.name, 'index.html'), 'utf8');
+    // The archive lists one card per post; the tag cloud below reports the same
+    // number, which is the value the template actually branched on.
+    const cards = (html.match(/class="[^"]*\bcard\b[^"]*"/g) ?? []).length;
+    const robots = html.match(/<meta name="robots" content="([^"]+)"/);
+    const inSitemap = sitemap.includes(`/en/tag/${entry.name}/<`);
+
+    if (cards < 3) {
+        check(`tag/${entry.name} (${cards} posts): noindex, follow`, robots?.[1] === 'noindex, follow', robots?.[1] ?? 'no robots meta');
+        check(`tag/${entry.name} (${cards} posts): absent from sitemap`, !inSitemap);
+    } else {
+        check(`tag/${entry.name} (${cards} posts): indexable`, !robots, robots?.[1] ?? '');
+        check(`tag/${entry.name} (${cards} posts): present in sitemap`, inSitemap);
+    }
+}
+
+// --- H4: dateModified is honest --------------------------------------------
+//
+// It may equal datePublished — most of these posts have never been revised —
+// but it must never precede it, and it must never be the build date.
+const today = new Date().toISOString().slice(0, 10);
+for (const [slug, html] of posts) {
+    const blog = [...html.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/gs)]
+        .map((m) => JSON.parse(m[1]))
+        .find((entry) => entry['@type'] === 'BlogPosting');
+
+    check(`${slug}: has BlogPosting`, Boolean(blog));
+    if (!blog) continue;
+
+    check(
+        `${slug}: dateModified >= datePublished`,
+        new Date(blog.dateModified) >= new Date(blog.datePublished),
+        `${blog.dateModified} < ${blog.datePublished}`
+    );
+    check(
+        `${slug}: dateModified is not the build date`,
+        !blog.dateModified.startsWith(today),
+        blog.dateModified
+    );
+}
+
+console.log(`\n${passed}/${passed + failed} passed`);
+process.exit(failed ? 1 : 0);

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -127,9 +127,23 @@ for (const entry of fs.readdirSync(tagDir, { withFileTypes: true })) {
 
 // --- H4: dateModified is honest --------------------------------------------
 //
-// It may equal datePublished — most of these posts have never been revised —
-// but it must never precede it, and it must never be the build date.
-const today = new Date().toISOString().slice(0, 10);
+// Compare against the editorial dates, not the wall clock: publishing or
+// genuinely revising a post on the day it is built is valid.
+const postDates = new Map(
+    fs.readdirSync('src/content/posts/en', { recursive: true })
+        .filter((file) => /\.mdx?$/.test(String(file)))
+        .map((file) => {
+            const source = fs.readFileSync(path.join('src/content/posts/en', String(file)), 'utf8');
+            const frontMatter = source.split('---')[1] ?? '';
+            // Posts declare YAML date scalars, e.g. date: 2025-03-10.
+            const date = frontMatter.match(/^date:[ \t]*(\S+)/m)?.[1];
+            const modified = frontMatter.match(/^modified:[ \t]*(\S+)/m)?.[1];
+            return [path.basename(String(file)).replace(/\.mdx?$/, ''), {
+                published: new Date(date).valueOf(),
+                modified: new Date(modified ?? date).valueOf()
+            }];
+        })
+);
 for (const [slug, html] of posts) {
     const blog = [...html.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/gs)]
         .map((m) => JSON.parse(m[1]))
@@ -144,8 +158,13 @@ for (const [slug, html] of posts) {
         `${blog.dateModified} < ${blog.datePublished}`
     );
     check(
-        `${slug}: dateModified is not the build date`,
-        !blog.dateModified.startsWith(today),
+        `${slug}: datePublished matches front matter`,
+        new Date(blog.datePublished).valueOf() === postDates.get(slug)?.published,
+        blog.datePublished
+    );
+    check(
+        `${slug}: dateModified matches front matter`,
+        new Date(blog.dateModified).valueOf() === postDates.get(slug)?.modified,
         blog.dateModified
     );
 }


### PR DESCRIPTION
Article images previously loaded lazily, and the related-post strip repeatedly linked to the newest three articles. This change prioritizes each post's first image, selects related articles by shared tags with coverage and recency tie-breaks, and excludes tag archives with fewer than three posts from indexing and the sitemap.

Stacked on #78. Merge #78 first, then this PR.

- All 12 post heroes use `loading="eager"` and `fetchpriority="high"`.
- Every existing article receives a related-post link; Iceland links to the Europe, Japan and Asia itineraries.
- Nine small tag archives use `noindex, follow`; the sitemap contains 24 URLs.
- Modification dates remain editorial front matter, with publication-date fallback. Validation rejects dates before publication and compares generated dates with front matter, allowing genuine same-day publication or updates.

The Japan and Ha Giang content refreshes remain deferred.

Validation: production build passed; 13 theme assertions and 127 SEO assertions passed. The combined stack also passes type checking. Fixed-clock checks accept a declared same-day refresh and reject an undeclared generated date change.
