### PR TITLE
fix(seo): drop dead hreflang, correct locale, trim the sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ heroImageAlt: A street scene in Japan
 seo:
   title: One Week Japan Itinerary
   description: How to visit Japan on a bougie backpacker budget!
-  changeFrequency: monthly
 ---
 ```
 
@@ -132,6 +131,15 @@ has never been revised. Don't mirror `date` into it; the schema rejects a
 purpose: `actions/checkout` stamps every file with the clone time, and a git
 last-commit date moves for build-only commits, so either would announce a
 refresh that never happened.
+
+Static pages under `src/pages/` export a `meta` object that the sitemap reads.
+Set `lastModified` (an ISO date) when you change one — it becomes the URL's
+`<lastmod>`, the one sitemap hint Google actually reads. It is declared rather
+than derived for the same reason `modified` is on posts: the build time would
+claim every page changed on every deploy, and `actions/checkout` stamps the
+whole tree with the clone time. `<priority>` and `<changefreq>` are not emitted
+at all — Google ignores both, and every page here had declared priority 1.0,
+which makes a relative signal say nothing.
 
 Every tag becomes an archive page at `/<lang>/tag/<tag>/` automatically. Add a
 display override to `TAG_LABEL_OVERRIDES` in `src/lib/format.ts` for any tag
@@ -234,6 +242,11 @@ drift apart.
 Spanish currently has no content. The machinery is in place: add
 `src/pages/es/<page>.astro` or `src/content/posts/es/<slug>.mdx` and the
 language switcher, `hreflang` tags, feeds and manifest pick it up automatically.
+
+Until then no `hreflang` is emitted at all, by design: a set naming only the
+page it sits on is self-referential and tells a crawler nothing the canonical
+doesn't. The moment a page has a translation it gets the full set — both
+languages plus `x-default` — because a partial set is ignored wholesale.
 
 ## Deployment
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,10 +16,6 @@ const seo = z
         description: z.string().optional(),
         /** Overrides the filename when building the URL. */
         slug: z.string().optional(),
-        changeFrequency: z
-            .enum(['always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never'])
-            .optional(),
-        sitemapPriority: z.string().optional(),
         excludeFromSitemap: z.boolean().default(false),
         noIndex: z.boolean().default(false)
     })

--- a/src/content/posts/en/asia/diy-lombok-loop.mdx
+++ b/src/content/posts/en/asia/diy-lombok-loop.mdx
@@ -13,7 +13,6 @@ heroImageAlt: Mt. Rinjani rising over a beach between the clouds
 seo:
   title: Lombok by Motorbike in 2025
   description: Everything you need to know before riding around Lombok on a motorbike!
-  changeFrequency: yearly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/asia/diy-the-ha-giang-loop.mdx
+++ b/src/content/posts/en/asia/diy-the-ha-giang-loop.mdx
@@ -13,7 +13,6 @@ heroImageAlt: Road carving through the mountains
 seo:
   title: DIY the Ha Giang Loop 2025
   description: Everything you need to know before doing this incredible ride on your own. 
-  changeFrequency: yearly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/asia/four-months-asia.mdx
+++ b/src/content/posts/en/asia/four-months-asia.mdx
@@ -14,7 +14,6 @@ heroImageAlt: Us on the coast of Cambodia
 seo:
   title: Four Months in Southeast Asia
   description: An overview of how we planned and executed our four month trip through Southeast Asia!
-  changeFrequency: monthly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/asia/komodo-island-tour.mdx
+++ b/src/content/posts/en/asia/komodo-island-tour.mdx
@@ -12,7 +12,6 @@ heroImage: /assets/img/posts/asia/komodocover.jpg
 heroImageAlt: Arial shot of islands surrounded by beaches and blue water
 seo:
   description: Everything you need to know before taking a tour around the Komodo Islands from Lauban Bajo.
-  changeFrequency: yearly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/asia/nias-island.mdx
+++ b/src/content/posts/en/asia/nias-island.mdx
@@ -13,7 +13,6 @@ heroImageAlt: Palm trees near the sea on Nias Island
 seo:
   title: How to Visit Nias in 2025
   description: How to visit the tiny island of Nias, Indonesia
-  changeFrequency: yearly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/asia/one-week-japan-itinerary.mdx
+++ b/src/content/posts/en/asia/one-week-japan-itinerary.mdx
@@ -15,7 +15,6 @@ heroImageAlt: Shinto temple in Tokyo with smoke in front of it
 seo:
   title: One Week Japan Itinerary
   description: How to visit Japan on a bougie backpacker budget!
-  changeFrequency: monthly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/europe/five-day-iceland-itinerary.mdx
+++ b/src/content/posts/en/europe/five-day-iceland-itinerary.mdx
@@ -14,7 +14,6 @@ heroImage: /assets/img/posts/europe/IMG_6912.jpg
 heroImageAlt: An Icelandic landscape
 seo:
   description: Follow along with us as we travel through Iceland for five days!
-  changeFrequency: never
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/europe/nine-months-europe.mdx
+++ b/src/content/posts/en/europe/nine-months-europe.mdx
@@ -13,7 +13,6 @@ heroImageAlt: Orange sunset over Norway Harbor
 seo:
   title: Nine Months in Europe 
   description: An overview of how we planned and executed our entire nine month Europe trip!
-  changeFrequency: never
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/reviews/ltt-commuter-backpack-review.mdx
+++ b/src/content/posts/en/reviews/ltt-commuter-backpack-review.mdx
@@ -12,7 +12,6 @@ heroImageAlt: The bag at a Japanese temple
 seo:
   title: One Month LTT Commuter Backpack Review
   description: Notes on the experience of using the LTT Commuter Backpack while traveling for one month.
-  changeFrequency: yearly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/tools/how-to-use-budget-sheets.mdx
+++ b/src/content/posts/en/tools/how-to-use-budget-sheets.mdx
@@ -13,7 +13,6 @@ heroImageAlt: A budget planning spreadsheet open in Google Sheets
 seo:
   title: How to Use the Budget Sheets
   description: How to use the budget sheets to maximize your money when planning a trip!
-  changeFrequency: yearly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/tools/how-to-use-planning-sheets.mdx
+++ b/src/content/posts/en/tools/how-to-use-planning-sheets.mdx
@@ -13,7 +13,6 @@ heroImageAlt: A trip itinerary planning spreadsheet open in Google Sheets
 seo:
   title: How to Use the Planning Sheets
   description: How to use the planning sheets to maximize your time and see all the places when planning your trips!
-  changeFrequency: yearly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/content/posts/en/tools/vpns.mdx
+++ b/src/content/posts/en/tools/vpns.mdx
@@ -13,7 +13,6 @@ heroImageAlt: A collection of computers and phones on a table.
 seo:
   title: All About VPNs
   description: VPNs are an important part of your online security toolkit - learn more about them from this article!
-  changeFrequency: yearly
 ---
 
 import Figure from '@components/Figure.astro';

--- a/src/data/locales.ts
+++ b/src/data/locales.ts
@@ -23,7 +23,11 @@ export const locales = {
         dir: 'ltr',
         label: 'English',
         shorthand: 'EN',
-        locale: 'en-gb',
+        // The site is written from Vancouver and served from a .ca domain, so
+        // en-gb was wrong in both <html lang> and og:locale. It also drives
+        // Intl date formatting, which now reads "March 10, 2025" rather than
+        // "10 March 2025".
+        locale: 'en-ca',
         postSegment: 'writing'
     },
     es: {

--- a/src/data/settings.js
+++ b/src/data/settings.js
@@ -82,10 +82,6 @@ export const settings = {
     // the Organization at a person's profile asserts they are the same entity.
     // Those live on the Person entries instead, with `founder` tying them here.
     organizationSameAs: [social.instagram, social.youtube],
-    seo: {
-        defaultChangeFrequency: 'monthly',
-        defaultPriority: '0.7'
-    },
     manifest: {
         themeColor: '#eceff4',
         backgroundColor: '#eceff4',

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -60,6 +60,15 @@ const socialImageAlt = imageAlt ?? translate('meta.opengraphDefaultAlt');
 const robotsContent = settings.isStaging ? 'noindex, nofollow' : noIndex ? robots : null;
 
 const alternates = localeLinks(pathname, lang);
+
+// x-default is the page a visitor gets when none of the languages match them.
+const defaultLangUrl =
+    lang === DEFAULT_LANG
+        ? canonical
+        : absoluteUrl(
+              alternates.find((link) => link.lang === DEFAULT_LANG)?.url ?? pathname,
+              settings.url
+          );
 const structuredData = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
 
 const feedXml = localeUrl('/feed/feed.xml', lang);
@@ -77,13 +86,27 @@ const manifest = localeUrl('/site.webmanifest', lang);
         <title>{fullTitle}</title>
         <meta name="description" content={metaDescription} />
 
-        <!-- canonical / alternates -->
+        <!-- canonical / alternates.
+             Only emitted where a translation actually exists: an hreflang set
+             naming a single page is self-referential and tells a crawler
+             nothing it can't read off the canonical. When one does exist the
+             set is complete — every language, plus x-default pointing at the
+             default one — because a partial set is ignored wholesale. -->
         <link rel="canonical" href={canonical} />
-        <link rel="alternate" hreflang={lang} href={canonical} />
         {
-            alternates.map((link) => (
-                <link rel="alternate" hreflang={link.lang} href={absoluteUrl(link.url, settings.url)} />
-            ))
+            alternates.length > 0 && (
+                <>
+                    <link rel="alternate" hreflang={lang} href={canonical} />
+                    {alternates.map((link) => (
+                        <link
+                            rel="alternate"
+                            hreflang={link.lang}
+                            href={absoluteUrl(link.url, settings.url)}
+                        />
+                    ))}
+                    <link rel="alternate" hreflang="x-default" href={defaultLangUrl} />
+                </>
+            )
         }
 
         <!-- open graph -->
@@ -135,6 +158,13 @@ const manifest = localeUrl('/site.webmanifest', lang);
         />
 
         <!-- everything else -->
+        <!-- Referrer-Policy is one of the few security headers a static host can
+             still set, since it has a meta equivalent. HSTS and
+             X-Content-Type-Options are response headers with no meta form, and
+             GitHub Pages does not allow custom headers — those need a proxy in
+             front. A meta CSP is possible but not added: it cannot carry a
+             nonce, and the inline theme script below has to keep running. -->
+        <meta name="referrer" content="strict-origin-when-cross-origin" />
         <meta name="google-site-verification" content={settings.meta.googleSiteVerification} />
         <link rel="manifest" href={manifest} />
         <meta name="theme-color" media="(prefers-color-scheme: light)" content={settings.themeColorLight} />

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -4,10 +4,9 @@ import Figure from '@components/Figure.astro';
 import { allPeople } from '@lib/schema';
 
 export const meta = {
+    lastModified: '2026-09-04',
     "title": "About Us",
     "lang": "en",
-    "changeFrequency": "daily",
-    "sitemapPriority": "1.0",
     "excludeFromSitemap": false
 };
 ---

--- a/src/pages/en/affiliates.astro
+++ b/src/pages/en/affiliates.astro
@@ -2,10 +2,9 @@
 import Page from '@layouts/Page.astro';
 
 export const meta = {
+    lastModified: '2026-08-09',
     "title": "Affiliates",
     "lang": "en",
-    "changeFrequency": "yearly",
-    "sitemapPriority": "1.0",
     "excludeFromSitemap": false
 };
 ---

--- a/src/pages/en/countries.astro
+++ b/src/pages/en/countries.astro
@@ -6,10 +6,9 @@ import { settings } from '@data/settings.js';
 import { absoluteUrl } from '@lib/i18n';
 
 export const meta = {
+    lastModified: '2026-09-04',
     "title": "Countries",
     "lang": "en",
-    "changeFrequency": "daily",
-    "sitemapPriority": "1.0",
     "excludeFromSitemap": false
 };
 

--- a/src/pages/en/do-not-sell-my-personal-information.astro
+++ b/src/pages/en/do-not-sell-my-personal-information.astro
@@ -2,10 +2,9 @@
 import Page from '@layouts/Page.astro';
 
 export const meta = {
+    lastModified: '2026-08-09',
     "title": "Do Not Sell My Personal Information",
     "lang": "en",
-    "changeFrequency": "yearly",
-    "sitemapPriority": "1.0",
     "excludeFromSitemap": false
 };
 ---

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -2,10 +2,9 @@
 import Page from '@layouts/Page.astro';
 
 export const meta = {
+    lastModified: '2026-08-09',
     "title": "Privacy Policy",
     "lang": "en",
-    "changeFrequency": "yearly",
-    "sitemapPriority": "1.0",
     "excludeFromSitemap": false
 };
 ---

--- a/src/pages/en/terms.astro
+++ b/src/pages/en/terms.astro
@@ -2,10 +2,9 @@
 import Page from '@layouts/Page.astro';
 
 export const meta = {
+    lastModified: '2026-08-09',
     "title": "Terms of Service",
     "lang": "en",
-    "changeFrequency": "yearly",
-    "sitemapPriority": "1.0",
     "excludeFromSitemap": false
 };
 ---

--- a/src/pages/en/tools.astro
+++ b/src/pages/en/tools.astro
@@ -3,10 +3,9 @@ import Page from '@layouts/Page.astro';
 import Figure from '@components/Figure.astro';
 
 export const meta = {
+    lastModified: '2026-08-09',
     "title": "Tools",
     "lang": "en",
-    "changeFrequency": "monthly",
-    "sitemapPriority": "1.0",
     "excludeFromSitemap": false
 };
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,10 +9,9 @@ import { absoluteUrl, localeUrl } from '@lib/i18n';
 import { getPosts, getPostsByTag, postUrl } from '@lib/posts';
 
 export const meta = {
+    lastModified: '2026-09-04',
     title: 'Travel Blog & Travel Guides',
     lang: 'en',
-    changeFrequency: 'weekly',
-    sitemapPriority: '1.0',
     excludeFromSitemap: false
 };
 

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,3 +1,10 @@
+// The sitemap carries <loc> and <lastmod> only.
+//
+// Google ignores <priority> and <changefreq>, and this site demonstrated why
+// they are worth dropping rather than tuning: every page declared priority 1.0,
+// including the privacy policy, which makes a relative signal say nothing at
+// all. <lastmod> is the one hint that is actually read, so it is now emitted
+// for every URL instead of only for posts and archives.
 import type { APIRoute } from 'astro';
 
 import { settings } from '@data/settings.js';
@@ -6,8 +13,8 @@ import { toRfc3339 } from '@lib/format';
 import { getPosts, getTagIndex, isThinTag, postUrl } from '@lib/posts';
 
 interface PageMetaExport {
-    changeFrequency?: string;
-    sitemapPriority?: string;
+    /** ISO date this page's content last actually changed. */
+    lastModified?: string;
     excludeFromSitemap?: boolean;
 }
 
@@ -26,8 +33,6 @@ const pageModules = import.meta.glob<Record<string, unknown>>('/src/pages/**/*.a
 interface UrlEntry {
     loc: string;
     lastmod?: string;
-    changefreq: string;
-    priority: string;
 }
 
 /** '/src/pages/en/about.astro' → '/en/about/' */
@@ -52,11 +57,11 @@ export const GET: APIRoute = async () => {
 
         entries.push({
             loc: absoluteUrl(routeOf(filePath), settings.url),
-            // No lastmod: an .astro page has no meaningful content date, and
-            // emitting the build time would claim every page changed on every
-            // deploy.
-            changefreq: meta?.changeFrequency ?? settings.seo.defaultChangeFrequency,
-            priority: meta?.sitemapPriority ?? settings.seo.defaultPriority
+            // Declared per page rather than derived. An .astro file has no
+            // content date of its own, and the two automatic sources both lie:
+            // the build time claims every page changed on every deploy, and
+            // `actions/checkout` stamps the whole tree with the clone time.
+            lastmod: meta?.lastModified
         });
     }
 
@@ -66,9 +71,7 @@ export const GET: APIRoute = async () => {
 
         entries.push({
             loc: absoluteUrl(postUrl(post), settings.url),
-            lastmod: toRfc3339(post.data.modified ?? post.data.date),
-            changefreq: post.data.seo?.changeFrequency ?? settings.seo.defaultChangeFrequency,
-            priority: post.data.seo?.sitemapPriority ?? settings.seo.defaultPriority
+            lastmod: toRfc3339(post.data.modified ?? post.data.date)
         });
     }
 
@@ -82,9 +85,8 @@ export const GET: APIRoute = async () => {
         const newest = entry.posts[0];
         entries.push({
             loc: absoluteUrl(`/${entry.lang}/tag/${entry.slug}/`, settings.url),
-            lastmod: newest ? toRfc3339(newest.data.modified ?? newest.data.date) : undefined,
-            changefreq: 'weekly',
-            priority: '0.5'
+            // An archive is as fresh as the newest thing it lists.
+            lastmod: newest ? toRfc3339(newest.data.modified ?? newest.data.date) : undefined
         });
     }
 
@@ -94,8 +96,6 @@ ${entries
     .map(
         (entry) => `	<url>
 		<loc>${entry.loc}</loc>${entry.lastmod ? `\n\t\t<lastmod>${entry.lastmod}</lastmod>` : ''}
-		<changefreq>${entry.changefreq}</changefreq>
-		<priority>${entry.priority}</priority>
 	</url>`
     )
     .join('\n')}

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -367,7 +367,6 @@ heroImageAlt: Aerial shot of islands surrounded by beaches and blue water
 seo:
   title: The Best Way to Visit the Komodo Islands in 2025
   description: Everything you need to know before taking a tour from Labuan Bajo.
-  changeFrequency: yearly
 ---
 `;
 

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -360,11 +360,28 @@ check('sitemap declares no changefreq', !sitemap.includes('<changefreq>'));
 const locs = (sitemap.match(/<loc>/g) ?? []).length;
 const lastmods = (sitemap.match(/<lastmod>/g) ?? []).length;
 check('every sitemap URL carries lastmod', locs === lastmods, `${lastmods} of ${locs}`);
-check(
-    'no lastmod claims the build date',
-    !sitemap.includes(`<lastmod>${today}`),
-    'a page is reporting today as its content date'
-);
+for (const [, entry] of sitemap.matchAll(/<url>([\s\S]*?)<\/url>/g)) {
+    const url = new URL(entry.match(/<loc>(.*?)<\/loc>/)[1]);
+    const lastmod = entry.match(/<lastmod>(.*?)<\/lastmod>/)?.[1];
+    check(`${url.pathname}: lastmod is a valid date`, Number.isFinite(Date.parse(lastmod)));
+
+    // Archive dates are derived from their posts; static pages and articles
+    // must match their declared editorial dates, even when that date is today.
+    if (url.pathname.includes('/tag/')) continue;
+    let expected;
+    if (url.pathname.startsWith('/en/writing/')) {
+        expected = postDates.get(url.pathname.split('/').at(-2))?.modified;
+    } else {
+        const file = url.pathname === '/' ? 'index' : url.pathname.slice(1, -1);
+        const source = fs.readFileSync(`src/pages/${file}.astro`, 'utf8');
+        expected = Date.parse(source.match(/lastModified:\s*['"]([^'"]+)['"]/)?.[1]);
+    }
+    check(
+        `${url.pathname}: lastmod matches the declared content date`,
+        Date.parse(lastmod) === expected,
+        lastmod
+    );
+}
 
 // --- the one security header a static host can still set -------------------
 check(

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -326,5 +326,51 @@ check(
     /class="svg-map-disabled" href="#NorthAmerica"/.test(countries)
 );
 
+// --- hreflang: complete, or absent -----------------------------------------
+//
+// A set naming only the page it sits on is self-referential and says nothing a
+// crawler can't read off the canonical. A partial set — alternates without
+// x-default — is ignored wholesale. So the only two valid states are "no
+// hreflang at all" and "every language plus x-default".
+const allPages = [
+    ['home', fs.readFileSync('dist/index.html', 'utf8')],
+    ['about', fs.readFileSync('dist/en/about/index.html', 'utf8')],
+    ...posts
+];
+
+for (const [name, html] of allPages) {
+    const tags = html.match(/<link rel="alternate" hreflang="[^"]*"[^>]*>/g) ?? [];
+    check(
+        `${name}: hreflang set is complete or absent`,
+        tags.length === 0 || tags.some((tag) => tag.includes('hreflang="x-default"')),
+        `${tags.length} alternates, no x-default`
+    );
+}
+
+// --- locale: .ca domain, authors in Vancouver ------------------------------
+for (const [name, html] of allPages) {
+    check(`${name}: html lang is en-ca`, /<html lang="en-ca"/.test(html));
+    check(`${name}: og:locale is en_ca`, /og:locale" content="en_ca"/.test(html));
+}
+
+// --- sitemap: lastmod on everything, nothing Google ignores ----------------
+check('sitemap declares no priority', !sitemap.includes('<priority>'));
+check('sitemap declares no changefreq', !sitemap.includes('<changefreq>'));
+
+const locs = (sitemap.match(/<loc>/g) ?? []).length;
+const lastmods = (sitemap.match(/<lastmod>/g) ?? []).length;
+check('every sitemap URL carries lastmod', locs === lastmods, `${lastmods} of ${locs}`);
+check(
+    'no lastmod claims the build date',
+    !sitemap.includes(`<lastmod>${today}`),
+    'a page is reporting today as its content date'
+);
+
+// --- the one security header a static host can still set -------------------
+check(
+    'referrer policy is declared',
+    /<meta name="referrer" content="strict-origin-when-cross-origin"/.test(home)
+);
+
 console.log(`\n${passed}/${passed + failed} passed`);
 process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Removes self-only hreflang markup, changes the English locale to en-ca, and simplifies the sitemap to locations and declared modification dates. Also adds the strict-origin-when-cross-origin referrer-policy meta tag.

Stacked on #80. Merge in order: #78 → #79 → #80 → #81.

- Pages with a translation receive language alternates and x-default; monolingual pages emit no hreflang.
- Static pages declare lastModified explicitly. All 24 sitemap URLs carry lastmod; priority and changefreq configuration is removed.
- Date tests compare static-page and article sitemap dates against declared content dates. A legitimate update on the build date is allowed.
- Incorporates the schema and article-date corrections from #79 and #80.

Custom response headers, asset cache policy, server-side redirects, llms.txt, and content refreshes remain outside this change.

Validation: type check passed with zero errors and zero warnings (three existing hints); production build passed; 13 theme assertions and 286 SEO assertions passed. A fixed September 4 clock and a simulated same-day article refresh both pass; an undeclared article-date change and each original schema defect are rejected.
